### PR TITLE
dep: updates to wazero 1.0.0-pre.3

### DIFF
--- a/examples/helloworld/greeting/greet.pb.go
+++ b/examples/helloworld/greeting/greet.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/helloworld/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 

--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/helloworld/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 
@@ -37,9 +37,7 @@ type GreeterPlugin struct {
 func NewGreeterPlugin(ctx context.Context, opt GreeterPluginOption) (*GreeterPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -60,18 +58,12 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string) (Greeter, e
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/helloworld/greeting/greet_plugin.pb.go
+++ b/examples/helloworld/greeting/greet_plugin.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/helloworld/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 

--- a/examples/helloworld/greeting/greet_vtproto.pb.go
+++ b/examples/helloworld/greeting/greet_vtproto.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/helloworld/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 

--- a/examples/host-functions/greeting/greet.pb.go
+++ b/examples/host-functions/greeting/greet.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/host-functions/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/host-functions/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 
@@ -26,69 +26,70 @@ type _hostFunctions struct {
 	HostFunctions
 }
 
-func (h _hostFunctions) Export() map[string]interface{} {
-	return map[string]interface{}{
-		"http_get": h._HttpGet(),
-		"log":      h._Log(),
-	}
+// Instantiate a Go-defined module named "env" that exports host functions.
+func (h _hostFunctions) Instantiate(ctx context.Context, r wazero.Runtime, ns wazero.Namespace) error {
+	envBuilder := r.NewHostModuleBuilder("env")
+
+	envBuilder.NewFunctionBuilder().WithFunc(h._HttpGet).Export("http_get")
+
+	envBuilder.NewFunctionBuilder().WithFunc(h._Log).Export("log")
+
+	_, err := envBuilder.Instantiate(ctx, ns)
+	return err
 }
 
 // Sends a HTTP GET request
 
-func (h _hostFunctions) _HttpGet() func(ctx context.Context, m api.Module, offset, size uint32) uint64 {
-	return func(ctx context.Context, m api.Module, offset, size uint32) uint64 {
-		buf, err := wasm.ReadMemory(ctx, m, offset, size)
-		if err != nil {
-			panic(err)
-		}
-		var request HttpGetRequest
-		err = request.UnmarshalVT(buf)
-		if err != nil {
-			panic(err)
-		}
-		resp, err := h.HttpGet(ctx, request)
-		if err != nil {
-			panic(err)
-		}
-		buf, err = resp.MarshalVT()
-		if err != nil {
-			panic(err)
-		}
-		ptr, err := wasm.WriteMemory(ctx, m, buf)
-		if err != nil {
-			panic(err)
-		}
-		return (ptr << uint64(32)) | uint64(len(buf))
+func (h _hostFunctions) _HttpGet(ctx context.Context, m api.Module, offset, size uint32) uint64 {
+	buf, err := wasm.ReadMemory(ctx, m, offset, size)
+	if err != nil {
+		panic(err)
 	}
+	var request HttpGetRequest
+	err = request.UnmarshalVT(buf)
+	if err != nil {
+		panic(err)
+	}
+	resp, err := h.HttpGet(ctx, request)
+	if err != nil {
+		panic(err)
+	}
+	buf, err = resp.MarshalVT()
+	if err != nil {
+		panic(err)
+	}
+	ptr, err := wasm.WriteMemory(ctx, m, buf)
+	if err != nil {
+		panic(err)
+	}
+	return (ptr << uint64(32)) | uint64(len(buf))
 }
 
 // Shows a log message
 
-func (h _hostFunctions) _Log() func(ctx context.Context, m api.Module, offset, size uint32) uint64 {
-	return func(ctx context.Context, m api.Module, offset, size uint32) uint64 {
-		buf, err := wasm.ReadMemory(ctx, m, offset, size)
-		if err != nil {
-			panic(err)
-		}
-		var request LogRequest
-		err = request.UnmarshalVT(buf)
-		if err != nil {
-			panic(err)
-		}
-		resp, err := h.Log(ctx, request)
-		if err != nil {
-			panic(err)
-		}
-		buf, err = resp.MarshalVT()
-		if err != nil {
-			panic(err)
-		}
-		ptr, err := wasm.WriteMemory(ctx, m, buf)
-		if err != nil {
-			panic(err)
-		}
-		return (ptr << uint64(32)) | uint64(len(buf))
+func (h _hostFunctions) _Log(ctx context.Context, m api.Module, offset, size uint32) uint64 {
+	buf, err := wasm.ReadMemory(ctx, m, offset, size)
+	if err != nil {
+		panic(err)
 	}
+	var request LogRequest
+	err = request.UnmarshalVT(buf)
+	if err != nil {
+		panic(err)
+	}
+	resp, err := h.Log(ctx, request)
+	if err != nil {
+		panic(err)
+	}
+	buf, err = resp.MarshalVT()
+	if err != nil {
+		panic(err)
+	}
+	ptr, err := wasm.WriteMemory(ctx, m, buf)
+	if err != nil {
+		panic(err)
+	}
+	return (ptr << uint64(32)) | uint64(len(buf))
 }
 
 const GreeterPluginAPIVersion = 1
@@ -107,9 +108,7 @@ type GreeterPlugin struct {
 func NewGreeterPlugin(ctx context.Context, opt GreeterPluginOption) (*GreeterPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -132,9 +131,7 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctio
 
 	h := _hostFunctions{hostFunctions}
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").ExportFunctions(h.Export()).Instantiate(ctx, ns)
-	if err != nil {
+	if err := h.Instantiate(ctx, p.runtime, ns); err != nil {
 		return nil, err
 	}
 
@@ -143,7 +140,7 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctio
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/host-functions/greeting/greet_plugin.pb.go
+++ b/examples/host-functions/greeting/greet_plugin.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/host-functions/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 

--- a/examples/host-functions/greeting/greet_vtproto.pb.go
+++ b/examples/host-functions/greeting/greet_vtproto.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/host-functions/greeting/greet.proto
+// source: greeting/greet.proto
 
 package greeting
 

--- a/examples/known-types/known/known.pb.go
+++ b/examples/known-types/known/known.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/known-types/known/known.proto
+// source: known/known.proto
 
 package known
 

--- a/examples/known-types/known/known_host.pb.go
+++ b/examples/known-types/known/known_host.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/known-types/known/known.proto
+// source: known/known.proto
 
 package known
 
@@ -37,9 +37,7 @@ type WellKnownPlugin struct {
 func NewWellKnownPlugin(ctx context.Context, opt WellKnownPluginOption) (*WellKnownPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -60,18 +58,12 @@ func (p *WellKnownPlugin) Load(ctx context.Context, pluginPath string) (WellKnow
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/known-types/known/known_plugin.pb.go
+++ b/examples/known-types/known/known_plugin.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/known-types/known/known.proto
+// source: known/known.proto
 
 package known
 

--- a/examples/known-types/known/known_vtproto.pb.go
+++ b/examples/known-types/known/known_vtproto.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/known-types/known/known.proto
+// source: known/known.proto
 
 package known
 

--- a/examples/wasi/cat/cat.pb.go
+++ b/examples/wasi/cat/cat.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/wasi/cat/cat.proto
+// source: cat/cat.proto
 
 package cat
 

--- a/examples/wasi/cat/cat_plugin.pb.go
+++ b/examples/wasi/cat/cat_plugin.pb.go
@@ -4,7 +4,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/wasi/cat/cat.proto
+// source: cat/cat.proto
 
 package cat
 

--- a/examples/wasi/cat/cat_vtproto.pb.go
+++ b/examples/wasi/cat/cat_vtproto.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go-plugin v0.1.0
 // 	protoc               v3.21.5
-// source: examples/wasi/cat/cat.proto
+// source: cat/cat.proto
 
 package cat
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/planetscale/vtprotobuf v0.3.0
 	github.com/stretchr/testify v1.7.1
-	github.com/tetratelabs/wazero v1.0.0-pre.1
+	github.com/tetratelabs/wazero v1.0.0-pre.3
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.0.0-pre.1 h1:bUZ4vf21c36RmgA3enNOlLgPElEVDYoRJJ9+McRGF6Q=
-github.com/tetratelabs/wazero v1.0.0-pre.1/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
+github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -37,9 +37,7 @@ type FieldTestPlugin struct {
 func NewFieldTestPlugin(ctx context.Context, opt FieldTestPluginOption) (*FieldTestPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -60,18 +58,12 @@ func (p *FieldTestPlugin) Load(ctx context.Context, pluginPath string) (FieldTes
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -37,9 +37,7 @@ type BarPlugin struct {
 func NewBarPlugin(ctx context.Context, opt BarPluginOption) (*BarPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -60,18 +58,12 @@ func (p *BarPlugin) Load(ctx context.Context, pluginPath string) (Bar, error) {
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -38,9 +38,7 @@ type FooPlugin struct {
 func NewFooPlugin(ctx context.Context, opt FooPluginOption) (*FooPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -61,18 +59,12 @@ func (p *FooPlugin) Load(ctx context.Context, pluginPath string) (Foo, error) {
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -38,9 +38,7 @@ type KnownTypesTestPlugin struct {
 func NewKnownTypesTestPlugin(ctx context.Context, opt KnownTypesTestPluginOption) (*KnownTypesTestPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -61,18 +59,12 @@ func (p *KnownTypesTestPlugin) Load(ctx context.Context, pluginPath string) (Kno
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}
@@ -191,9 +183,7 @@ type EmptyTestPlugin struct {
 func NewEmptyTestPlugin(ctx context.Context, opt EmptyTestPluginOption) (*EmptyTestPlugin, error) {
 
 	// Create a new WebAssembly Runtime.
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		// WebAssembly 2.0 allows use of any version of TinyGo, including 0.24+.
-		WithWasmCore2())
+	r := wazero.NewRuntime(ctx)
 
 	// Combine the above into our baseline config, overriding defaults.
 	config := wazero.NewModuleConfig().
@@ -214,18 +204,12 @@ func (p *EmptyTestPlugin) Load(ctx context.Context, pluginPath string) (EmptyTes
 	// Create an empty namespace so that multiple modules will not conflict
 	ns := p.runtime.NewNamespace(ctx)
 
-	// Instantiate a Go-defined module named "env" that exports functions.
-	_, err = p.runtime.NewModuleBuilder("env").Instantiate(ctx, ns)
-	if err != nil {
-		return nil, err
-	}
-
 	if _, err = wasi_snapshot_preview1.NewBuilder(p.runtime).Instantiate(ctx, ns); err != nil {
 		return nil, err
 	}
 
 	// Compile the WebAssembly module using the default configuration.
-	code, err := p.runtime.CompileModule(ctx, b, wazero.NewCompileConfig())
+	code, err := p.runtime.CompileModule(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/types/known/anypb/any.pb.go
+++ b/types/known/anypb/any.pb.go
@@ -31,45 +31,45 @@ const (
 //
 // Example 1: Pack and unpack a message in C++.
 //
-//     Foo foo = ...;
-//     Any any;
-//     any.PackFrom(foo);
-//     ...
-//     if (any.UnpackTo(&foo)) {
-//       ...
-//     }
+//	Foo foo = ...;
+//	Any any;
+//	any.PackFrom(foo);
+//	...
+//	if (any.UnpackTo(&foo)) {
+//	  ...
+//	}
 //
 // Example 2: Pack and unpack a message in Java.
 //
-//     Foo foo = ...;
-//     Any any = Any.pack(foo);
-//     ...
-//     if (any.is(Foo.class)) {
-//       foo = any.unpack(Foo.class);
-//     }
+//	Foo foo = ...;
+//	Any any = Any.pack(foo);
+//	...
+//	if (any.is(Foo.class)) {
+//	  foo = any.unpack(Foo.class);
+//	}
 //
 // Example 3: Pack and unpack a message in Python.
 //
-//     foo = Foo(...)
-//     any = Any()
-//     any.Pack(foo)
-//     ...
-//     if any.Is(Foo.DESCRIPTOR):
-//       any.Unpack(foo)
-//       ...
+//	foo = Foo(...)
+//	any = Any()
+//	any.Pack(foo)
+//	...
+//	if any.Is(Foo.DESCRIPTOR):
+//	  any.Unpack(foo)
+//	  ...
 //
 // Example 4: Pack and unpack a message in Go
 //
-//      foo := &pb.Foo{...}
-//      any, err := anypb.New(foo)
-//      if err != nil {
-//        ...
-//      }
-//      ...
-//      foo := &pb.Foo{}
-//      if err := any.UnmarshalTo(foo); err != nil {
-//        ...
-//      }
+//	foo := &pb.Foo{...}
+//	any, err := anypb.New(foo)
+//	if err != nil {
+//	  ...
+//	}
+//	...
+//	foo := &pb.Foo{}
+//	if err := any.UnmarshalTo(foo); err != nil {
+//	  ...
+//	}
 //
 // The pack methods provided by protobuf library will by default use
 // 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -77,35 +77,33 @@ const (
 // in the type URL, for example "foo.bar.com/x/y.z" will yield type
 // name "y.z".
 //
-//
-// JSON
+// # JSON
 //
 // The JSON representation of an `Any` value uses the regular
 // representation of the deserialized, embedded message, with an
 // additional field `@type` which contains the type URL. Example:
 //
-//     package google.profile;
-//     message Person {
-//       string first_name = 1;
-//       string last_name = 2;
-//     }
+//	package google.profile;
+//	message Person {
+//	  string first_name = 1;
+//	  string last_name = 2;
+//	}
 //
-//     {
-//       "@type": "type.googleapis.com/google.profile.Person",
-//       "firstName": <string>,
-//       "lastName": <string>
-//     }
+//	{
+//	  "@type": "type.googleapis.com/google.profile.Person",
+//	  "firstName": <string>,
+//	  "lastName": <string>
+//	}
 //
 // If the embedded message type is well-known and has a custom JSON
 // representation, that representation will be embedded adding a field
 // `value` which holds the custom JSON in addition to the `@type`
 // field. Example (for message [google.protobuf.Duration][]):
 //
-//     {
-//       "@type": "type.googleapis.com/google.protobuf.Duration",
-//       "value": "1.212s"
-//     }
-//
+//	{
+//	  "@type": "type.googleapis.com/google.protobuf.Duration",
+//	  "value": "1.212s"
+//	}
 type Any struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -123,14 +121,14 @@ type Any struct {
 	// scheme `http`, `https`, or no scheme, one can optionally set up a type
 	// server that maps type URLs to message definitions as follows:
 	//
-	// * If no scheme is provided, `https` is assumed.
-	// * An HTTP GET on the URL must yield a [google.protobuf.Type][]
-	//   value in binary format, or produce an error.
-	// * Applications are allowed to cache lookup results based on the
-	//   URL, or have them precompiled into a binary to avoid any
-	//   lookup. Therefore, binary compatibility needs to be preserved
-	//   on changes to types. (Use versioned type names to manage
-	//   breaking changes.)
+	//   - If no scheme is provided, `https` is assumed.
+	//   - An HTTP GET on the URL must yield a [google.protobuf.Type][]
+	//     value in binary format, or produce an error.
+	//   - Applications are allowed to cache lookup results based on the
+	//     URL, or have them precompiled into a binary to avoid any
+	//     lookup. Therefore, binary compatibility needs to be preserved
+	//     on changes to types. (Use versioned type names to manage
+	//     breaking changes.)
 	//
 	// Note: this functionality is not currently available in the official
 	// protobuf release, and it is not used for type URLs beginning with
@@ -138,7 +136,6 @@ type Any struct {
 	//
 	// Schemes other than `http`, `https` (or the empty scheme) might be
 	// used with implementation specific semantics.
-	//
 	TypeUrl string `protobuf:"bytes,1,opt,name=type_url,json=typeUrl,proto3" json:"type_url,omitempty"`
 	// Must be a valid serialized protocol buffer of the above specified type.
 	Value []byte `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`

--- a/types/known/durationpb/duration.pb.go
+++ b/types/known/durationpb/duration.pb.go
@@ -34,43 +34,43 @@ const (
 //
 // Example 1: Compute Duration from two Timestamps in pseudo code.
 //
-//     Timestamp start = ...;
-//     Timestamp end = ...;
-//     Duration duration = ...;
+//	Timestamp start = ...;
+//	Timestamp end = ...;
+//	Duration duration = ...;
 //
-//     duration.seconds = end.seconds - start.seconds;
-//     duration.nanos = end.nanos - start.nanos;
+//	duration.seconds = end.seconds - start.seconds;
+//	duration.nanos = end.nanos - start.nanos;
 //
-//     if (duration.seconds < 0 && duration.nanos > 0) {
-//       duration.seconds += 1;
-//       duration.nanos -= 1000000000;
-//     } else if (duration.seconds > 0 && duration.nanos < 0) {
-//       duration.seconds -= 1;
-//       duration.nanos += 1000000000;
-//     }
+//	if (duration.seconds < 0 && duration.nanos > 0) {
+//	  duration.seconds += 1;
+//	  duration.nanos -= 1000000000;
+//	} else if (duration.seconds > 0 && duration.nanos < 0) {
+//	  duration.seconds -= 1;
+//	  duration.nanos += 1000000000;
+//	}
 //
 // Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
 //
-//     Timestamp start = ...;
-//     Duration duration = ...;
-//     Timestamp end = ...;
+//	Timestamp start = ...;
+//	Duration duration = ...;
+//	Timestamp end = ...;
 //
-//     end.seconds = start.seconds + duration.seconds;
-//     end.nanos = start.nanos + duration.nanos;
+//	end.seconds = start.seconds + duration.seconds;
+//	end.nanos = start.nanos + duration.nanos;
 //
-//     if (end.nanos < 0) {
-//       end.seconds -= 1;
-//       end.nanos += 1000000000;
-//     } else if (end.nanos >= 1000000000) {
-//       end.seconds += 1;
-//       end.nanos -= 1000000000;
-//     }
+//	if (end.nanos < 0) {
+//	  end.seconds -= 1;
+//	  end.nanos += 1000000000;
+//	} else if (end.nanos >= 1000000000) {
+//	  end.seconds += 1;
+//	  end.nanos -= 1000000000;
+//	}
 //
 // Example 3: Compute Duration from datetime.timedelta in Python.
 //
-//     td = datetime.timedelta(days=3, minutes=10)
-//     duration = Duration()
-//     duration.FromTimedelta(td)
+//	td = datetime.timedelta(days=3, minutes=10)
+//	duration = Duration()
+//	duration.FromTimedelta(td)
 //
 // # JSON Mapping
 //
@@ -81,8 +81,6 @@ const (
 // encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 // be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 // microsecond should be expressed in JSON format as "3.000001s".
-//
-//
 type Duration struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/types/known/emptypb/empty.pb.go
+++ b/types/known/emptypb/empty.pb.go
@@ -27,10 +27,9 @@ const (
 // empty messages in your APIs. A typical example is to use it as the request
 // or the response type of an API method. For instance:
 //
-//     service Foo {
-//       rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
-//     }
-//
+//	service Foo {
+//	  rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+//	}
 type Empty struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/types/known/structpb/struct.pb.go
+++ b/types/known/structpb/struct.pb.go
@@ -26,7 +26,7 @@ const (
 // `NullValue` is a singleton enumeration to represent the null value for the
 // `Value` type union.
 //
-//  The JSON representation for `NullValue` is JSON `null`.
+//	The JSON representation for `NullValue` is JSON `null`.
 type NullValue int32
 
 const (
@@ -92,6 +92,7 @@ type Value struct {
 	// The kind of value.
 	//
 	// Types that are assignable to Kind:
+	//
 	//	*Value_NullValue
 	//	*Value_NumberValue
 	//	*Value_StringValue


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3). This is the last release that will build with Go 1.17.

Notably, this improves performance and changes host function syntax.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
