### PR TITLE
Fixes for empty input cases

### DIFF
--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -139,6 +139,7 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -155,7 +156,7 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		}
 	}
 
-	ptrSize, err := p.greet.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.greet.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -137,24 +137,25 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.greet.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.greet.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -229,24 +229,25 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.greet.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.greet.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -231,6 +231,7 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -247,7 +248,7 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		}
 	}
 
-	ptrSize, err := p.greet.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.greet.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/examples/known-types/known/known_host.pb.go
+++ b/examples/known-types/known/known_host.pb.go
@@ -139,6 +139,7 @@ func (p *wellKnownPlugin) Diff(ctx context.Context, request DiffRequest) (respon
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -155,7 +156,7 @@ func (p *wellKnownPlugin) Diff(ctx context.Context, request DiffRequest) (respon
 		}
 	}
 
-	ptrSize, err := p.diff.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.diff.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -137,24 +137,25 @@ func (p *fileCatPlugin) Cat(ctx context.Context, request FileCatRequest) (respon
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.cat.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.cat.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -139,6 +139,7 @@ func (p *fileCatPlugin) Cat(ctx context.Context, request FileCatRequest) (respon
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -155,7 +156,7 @@ func (p *fileCatPlugin) Cat(ctx context.Context, request FileCatRequest) (respon
 		}
 	}
 
-	ptrSize, err := p.cat.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.cat.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/gen/host.go
+++ b/gen/host.go
@@ -303,23 +303,23 @@ func genPluginMethod(g *protogen.GeneratedFile, f *fileInfo, method *protogen.Me
 	g.P("data, err := request.MarshalVT()")
 	g.P(errorHandling)
 	g.P("dataSize := uint64(len(data))")
-	g.P(`if dataSize == 0 {
-			return response, nil 
-		}`)
-	g.P("results, err := p.malloc.Call(ctx, dataSize)")
-	g.P(errorHandling)
-
 	g.P(`
-			dataPtr := results[0]
-			// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-			// So, we have to free it when finished
-			defer p.free.Call(ctx, dataPtr)
+			var dataPtr uint64
+			// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
+			if dataSize != 0 {
+				results, err := p.malloc.Call(ctx, dataSize)
+				if err != nil {return response , err}
+				dataPtr = results[0]
+				// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+				// So, we have to free it when finished
+				defer p.free.Call(ctx, dataPtr)
 
-			// The pointer is a linear memory offset, which is where we write the name.
-			if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {`)
-
-	errorMsg := `fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))`
-	g.P("return response, ", errorMsg, "}")
+				// The pointer is a linear memory offset, which is where we write the name.
+				if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+					return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+				}
+			}
+`)
 	g.P("ptrSize, err := p.", strings.ToLower(method.GoName[:1]+method.GoName[1:]),
 		".Call(ctx, dataPtr, dataSize)")
 	g.P(errorHandling)

--- a/tests/fields/fields_test.go
+++ b/tests/fields/fields_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/knqyf263/go-plugin/types/known/emptypb"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,10 @@ func TestFields(t *testing.T) {
 
 	plugin, err := p.Load(ctx, "plugin/plugin.wasm")
 	require.NoError(t, err)
+
+	res, err := plugin.TestEmptyInput(ctx, emptypb.Empty{})
+	require.NoError(t, err)
+	require.True(t, res.GetOk())
 
 	got, err := plugin.Test(ctx, proto.Request{
 		A: 1.2,

--- a/tests/fields/fields_test.go
+++ b/tests/fields/fields_test.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"context"
-	"github.com/knqyf263/go-plugin/types/known/emptypb"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/knqyf263/go-plugin/tests/fields/proto"
+	"github.com/knqyf263/go-plugin/types/known/emptypb"
 )
 
 func TestFields(t *testing.T) {

--- a/tests/fields/plugin/plugin.go
+++ b/tests/fields/plugin/plugin.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"github.com/knqyf263/go-plugin/types/known/emptypb"
 
 	"github.com/knqyf263/go-plugin/tests/fields/proto"
 )
@@ -15,6 +16,10 @@ func main() {
 }
 
 type TestPlugin struct{}
+
+func (p TestPlugin) TestEmptyInput(_ context.Context, _ emptypb.Empty) (proto.TestEmptyInputResponse, error) {
+	return proto.TestEmptyInputResponse{Ok: true}, nil
+}
 
 func (p TestPlugin) Test(_ context.Context, request proto.Request) (proto.Response, error) {
 	return proto.Response{

--- a/tests/fields/proto/fields.pb.go
+++ b/tests/fields/proto/fields.pb.go
@@ -8,6 +8,7 @@ package proto
 
 import (
 	context "context"
+	emptypb "github.com/knqyf263/go-plugin/types/known/emptypb"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
@@ -45,6 +46,25 @@ func (x Enum) Enum() *Enum {
 	p := new(Enum)
 	*p = x
 	return p
+}
+
+type TestEmptyInputResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Ok bool `protobuf:"varint,1,opt,name=ok,proto3" json:"ok,omitempty"`
+}
+
+func (x *TestEmptyInputResponse) ProtoReflect() protoreflect.Message {
+	panic(`not implemented`)
+}
+
+func (x *TestEmptyInputResponse) GetOk() bool {
+	if x != nil {
+		return x.Ok
+	}
+	return false
 }
 
 type Request struct {
@@ -433,4 +453,5 @@ func (x *Response_Nested) GetA() string {
 // go:plugin type=plugin version=1
 type FieldTest interface {
 	Test(context.Context, Request) (Response, error)
+	TestEmptyInput(context.Context, emptypb.Empty) (TestEmptyInputResponse, error)
 }

--- a/tests/fields/proto/fields.proto
+++ b/tests/fields/proto/fields.proto
@@ -1,11 +1,18 @@
 syntax = "proto3";
 package greeting;
 
+import "google/protobuf/empty.proto";
+
 option go_package = "github.com/knqyf263/go-plugin/test/fields/proto";
 
 // go:plugin type=plugin version=1
 service FieldTest {
   rpc Test(Request) returns (Response) {}
+  rpc TestEmptyInput(google.protobuf.Empty) returns (TestEmptyInputResponse) {}
+}
+
+message TestEmptyInputResponse {
+  bool ok = 1;
 }
 
 enum Enum {

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -139,6 +139,7 @@ func (p *fieldTestPlugin) Test(ctx context.Context, request Request) (response R
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -155,7 +156,7 @@ func (p *fieldTestPlugin) Test(ctx context.Context, request Request) (response R
 		}
 	}
 
-	ptrSize, err := p.test.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.test.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -137,24 +137,25 @@ func (p *fieldTestPlugin) Test(ctx context.Context, request Request) (response R
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.test.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.test.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/fields/proto/fields_plugin.pb.go
+++ b/tests/fields/proto/fields_plugin.pb.go
@@ -10,6 +10,7 @@ package proto
 
 import (
 	context "context"
+	emptypb "github.com/knqyf263/go-plugin/types/known/emptypb"
 	wasm "github.com/knqyf263/go-plugin/wasm"
 )
 
@@ -34,6 +35,26 @@ func _field_test_test(ptr, size uint32) uint64 {
 		return 0
 	}
 	response, err := fieldTest.Test(context.Background(), req)
+	if err != nil {
+		return 0
+	}
+
+	b, err = response.MarshalVT()
+	if err != nil {
+		return 0
+	}
+	ptr, size = wasm.ByteToPtr(b)
+	return (uint64(ptr) << uint64(32)) | uint64(size)
+}
+
+//export field_test_test_empty_input
+func _field_test_test_empty_input(ptr, size uint32) uint64 {
+	b := wasm.PtrToByte(ptr, size)
+	var req emptypb.Empty
+	if err := req.UnmarshalVT(b); err != nil {
+		return 0
+	}
+	response, err := fieldTest.TestEmptyInput(context.Background(), req)
 	if err != nil {
 		return 0
 	}

--- a/tests/fields/proto/fields_vtproto.pb.go
+++ b/tests/fields/proto/fields_vtproto.pb.go
@@ -22,6 +22,49 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+func (m *TestEmptyInputResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TestEmptyInputResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *TestEmptyInputResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Ok {
+		i--
+		if m.Ok {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *Request_Nested) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -505,6 +548,21 @@ func encodeVarint(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
+func (m *TestEmptyInputResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Ok {
+		n += 2
+	}
+	if m.unknownFields != nil {
+		n += len(m.unknownFields)
+	}
+	return n
+}
+
 func (m *Request_Nested) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -727,6 +785,77 @@ func sov(x uint64) (n int) {
 }
 func soz(x uint64) (n int) {
 	return sov(uint64((x << 1) ^ uint64((int64(x) >> 63))))
+}
+func (m *TestEmptyInputResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TestEmptyInputResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TestEmptyInputResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Ok", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.Ok = bool(v != 0)
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
 }
 func (m *Request_Nested) UnmarshalVT(dAtA []byte) error {
 	l := len(dAtA)

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -193,24 +193,25 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.greet.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.greet.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -195,6 +195,7 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -211,7 +212,7 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		}
 	}
 
-	ptrSize, err := p.greet.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.greet.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -139,6 +139,7 @@ func (p *barPlugin) Hello(ctx context.Context, request Request) (response Reply,
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -155,7 +156,7 @@ func (p *barPlugin) Hello(ctx context.Context, request Request) (response Reply,
 		}
 	}
 
-	ptrSize, err := p.hello.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.hello.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -137,24 +137,25 @@ func (p *barPlugin) Hello(ctx context.Context, request Request) (response Reply,
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.hello.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.hello.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -140,6 +140,7 @@ func (p *fooPlugin) Hello(ctx context.Context, request Request) (response bar.Re
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -156,7 +157,7 @@ func (p *fooPlugin) Hello(ctx context.Context, request Request) (response bar.Re
 		}
 	}
 
-	ptrSize, err := p.hello.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.hello.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -138,24 +138,25 @@ func (p *fooPlugin) Hello(ctx context.Context, request Request) (response bar.Re
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.hello.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.hello.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -140,6 +140,7 @@ func (p *knownTypesTestPlugin) Test(ctx context.Context, request Request) (respo
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -156,7 +157,7 @@ func (p *knownTypesTestPlugin) Test(ctx context.Context, request Request) (respo
 		}
 	}
 
-	ptrSize, err := p.test.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.test.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}
@@ -297,6 +298,7 @@ func (p *emptyTestPlugin) DoNothing(ctx context.Context, request emptypb.Empty) 
 	dataSize := uint64(len(data))
 
 	var dataPtr uint64
+	// If the input data is not empty, we must allocate the in-Wasm memory to store it, and pass to the plugin.
 	if dataSize != 0 {
 		results, err := p.malloc.Call(ctx, dataSize)
 		if err != nil {
@@ -313,7 +315,7 @@ func (p *emptyTestPlugin) DoNothing(ctx context.Context, request emptypb.Empty) 
 		}
 	}
 
-	ptrSize, err := p.donothing.Call(ctx, uint32(dataPtr), dataSize)
+	ptrSize, err := p.donothing.Call(ctx, dataPtr, dataSize)
 	if err != nil {
 		return response, err
 	}

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -138,24 +138,25 @@ func (p *knownTypesTestPlugin) Test(ctx context.Context, request Request) (respo
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.test.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.test.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}
@@ -294,24 +295,25 @@ func (p *emptyTestPlugin) DoNothing(ctx context.Context, request emptypb.Empty) 
 		return response, err
 	}
 	dataSize := uint64(len(data))
-	if dataSize == 0 {
-		return response, nil
-	}
-	results, err := p.malloc.Call(ctx, dataSize)
-	if err != nil {
-		return response, err
+
+	var dataPtr uint64
+	if dataSize != 0 {
+		results, err := p.malloc.Call(ctx, dataSize)
+		if err != nil {
+			return response, err
+		}
+		dataPtr = results[0]
+		// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
+		// So, we have to free it when finished
+		defer p.free.Call(ctx, dataPtr)
+
+		// The pointer is a linear memory offset, which is where we write the name.
+		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		}
 	}
 
-	dataPtr := results[0]
-	// This pointer is managed by TinyGo, but TinyGo is unaware of external usage.
-	// So, we have to free it when finished
-	defer p.free.Call(ctx, dataPtr)
-
-	// The pointer is a linear memory offset, which is where we write the name.
-	if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-		return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
-	}
-	ptrSize, err := p.donothing.Call(ctx, dataPtr, dataSize)
+	ptrSize, err := p.donothing.Call(ctx, uint32(dataPtr), dataSize)
 	if err != nil {
 		return response, err
 	}


### PR DESCRIPTION
This fixes a bug that makes it impossible to call empty-input plugins. It was introduced in #9 

fixes #11 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>
