### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOPATH := $(shell go env GOPATH)
 GOBIN := $(if $(GOPATH),$(GOPATH)/bin,/usr/local/bin)
 
-go_sources   := $(shell find cmd encoding gen genid version wasm -name "*.go")
+go_sources := $(shell find cmd encoding gen genid version wasm -name "*.go")
 
 .PHONY: build
 build: $(GOBIN)/protoc-gen-go-plugin
@@ -19,7 +19,6 @@ build.tests: $(tinygo_tests:.go=.wasm)
 
 %.wasm: %.go $(GOBIN)/protoc-gen-go-plugin
 	tinygo build -o $@ -scheduler=none --no-debug --target=wasi $<
-
 
 proto_files := $(shell find . -name "*.proto")
 .PHONY: protoc

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -51,8 +51,8 @@ func (h _hostFunctions) Instantiate(ctx context.Context, r wazero.Runtime, ns wa
 
 // Sends a HTTP GET request
 
-func (h _hostFunctions) _HttpGet(ctx context.Context, m api.Module, params []uint64) []uint64 {
-	offset, size := uint32(params[0]), uint32(params[1])
+func (h _hostFunctions) _HttpGet(ctx context.Context, m api.Module, stack []uint64) {
+	offset, size := uint32(stack[0]), uint32(stack[1])
 	buf, err := wasm.ReadMemory(ctx, m, offset, size)
 	if err != nil {
 		panic(err)
@@ -75,13 +75,13 @@ func (h _hostFunctions) _HttpGet(ctx context.Context, m api.Module, params []uin
 		panic(err)
 	}
 	ptrLen := (ptr << uint64(32)) | uint64(len(buf))
-	return []uint64{ptrLen}
+	stack[0] = ptrLen
 }
 
 // Shows a log message
 
-func (h _hostFunctions) _Log(ctx context.Context, m api.Module, params []uint64) []uint64 {
-	offset, size := uint32(params[0]), uint32(params[1])
+func (h _hostFunctions) _Log(ctx context.Context, m api.Module, stack []uint64) {
+	offset, size := uint32(stack[0]), uint32(stack[1])
 	buf, err := wasm.ReadMemory(ctx, m, offset, size)
 	if err != nil {
 		panic(err)
@@ -104,7 +104,7 @@ func (h _hostFunctions) _Log(ctx context.Context, m api.Module, params []uint64)
 		panic(err)
 	}
 	ptrLen := (ptr << uint64(32)) | uint64(len(buf))
-	return []uint64{ptrLen}
+	stack[0] = ptrLen
 }
 
 const GreeterPluginAPIVersion = 1

--- a/gen/host.go
+++ b/gen/host.go
@@ -69,13 +69,13 @@ func (gg *Generator) genHostFunctions(g *protogen.GeneratedFile, f *fileInfo) {
 		}`
 	for _, method := range f.hostService.Methods {
 		g.P(method.Comments.Leading, fmt.Sprintf(`
-			func (h %s) _%s(ctx %s, m %s, params []uint64) []uint64 {`,
+			func (h %s) _%s(ctx %s, m %s, stack []uint64) {`,
 			structName,
 			method.GoName,
 			g.QualifiedGoIdent(contextPackage.Ident("Context")),
 			g.QualifiedGoIdent(wazeroAPIPackage.Ident("Module")),
 		))
-		g.P("offset, size := uint32(params[0]), uint32(params[1])")
+		g.P("offset, size := uint32(stack[0]), uint32(stack[1])")
 		g.P("buf, err := ", g.QualifiedGoIdent(pluginWasmPackage.Ident("ReadMemory")), "(ctx, m, offset, size)")
 		g.P(errorHandling)
 
@@ -93,7 +93,7 @@ func (gg *Generator) genHostFunctions(g *protogen.GeneratedFile, f *fileInfo) {
 		g.P(errorHandling)
 
 		g.P("ptrLen := (ptr << uint64(32)) | uint64(len(buf))")
-		g.P("return []uint64{ptrLen}")
+		g.P("stack[0] = ptrLen")
 		g.P("}")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/planetscale/vtprotobuf v0.3.0
 	github.com/stretchr/testify v1.7.1
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -44,8 +44,8 @@ func (h _hostFunctions) Instantiate(ctx context.Context, r wazero.Runtime, ns wa
 	return err
 }
 
-func (h _hostFunctions) _ParseJson(ctx context.Context, m api.Module, params []uint64) []uint64 {
-	offset, size := uint32(params[0]), uint32(params[1])
+func (h _hostFunctions) _ParseJson(ctx context.Context, m api.Module, stack []uint64) {
+	offset, size := uint32(stack[0]), uint32(stack[1])
 	buf, err := wasm.ReadMemory(ctx, m, offset, size)
 	if err != nil {
 		panic(err)
@@ -68,7 +68,7 @@ func (h _hostFunctions) _ParseJson(ctx context.Context, m api.Module, params []u
 		panic(err)
 	}
 	ptrLen := (ptr << uint64(32)) | uint64(len(buf))
-	return []uint64{ptrLen}
+	stack[0] = ptrLen
 }
 
 const GreeterPluginAPIVersion = 1


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
