### PR TITLE
Removes context parameter from instruction-scoped operations 

### DIFF
--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -151,8 +151,8 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -166,10 +166,10 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -243,8 +243,8 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -258,10 +258,10 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/examples/known-types/known/known_host.pb.go
+++ b/examples/known-types/known/known_host.pb.go
@@ -151,8 +151,8 @@ func (p *wellKnownPlugin) Diff(ctx context.Context, request DiffRequest) (respon
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -166,10 +166,10 @@ func (p *wellKnownPlugin) Diff(ctx context.Context, request DiffRequest) (respon
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -151,8 +151,8 @@ func (p *fileCatPlugin) Cat(ctx context.Context, request FileCatRequest) (respon
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -166,10 +166,10 @@ func (p *fileCatPlugin) Cat(ctx context.Context, request FileCatRequest) (respon
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/gen/host.go
+++ b/gen/host.go
@@ -315,8 +315,8 @@ func genPluginMethod(g *protogen.GeneratedFile, f *fileInfo, method *protogen.Me
 				defer p.free.Call(ctx, dataPtr)
 
 				// The pointer is a linear memory offset, which is where we write the name.
-				if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-					return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+				if !p.module.Memory().Write(uint32(dataPtr), data) {
+					return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 				}
 			}
 `)
@@ -329,10 +329,10 @@ func genPluginMethod(g *protogen.GeneratedFile, f *fileInfo, method *protogen.Me
 			resSize := uint32(ptrSize[0])
 
 			// The pointer is a linear memory offset, which is where we write the name.
-			bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+			bytes, ok := p.module.Memory().Read(resPtr, resSize)
 			if !ok {
 				return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-					resPtr, resSize, p.module.Memory().Size(ctx))
+					resPtr, resSize, p.module.Memory().Size())
 			}
 
 			if err = response.UnmarshalVT(bytes); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/planetscale/vtprotobuf v0.3.0
 	github.com/stretchr/testify v1.7.1
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.5
 	google.golang.org/protobuf v1.28.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.5 h1:ChZsQewsazFwF+NT6qAKPwnqqiOlf2MN0aah1dlD8Bk=
+github.com/tetratelabs/wazero v1.0.0-pre.5/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -158,8 +158,8 @@ func (p *fieldTestPlugin) Test(ctx context.Context, request Request) (response R
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -173,10 +173,10 @@ func (p *fieldTestPlugin) Test(ctx context.Context, request Request) (response R
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {
@@ -205,8 +205,8 @@ func (p *fieldTestPlugin) TestEmptyInput(ctx context.Context, request emptypb.Em
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -220,10 +220,10 @@ func (p *fieldTestPlugin) TestEmptyInput(ctx context.Context, request emptypb.Em
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -207,8 +207,8 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -222,10 +222,10 @@ func (p *greeterPlugin) Greet(ctx context.Context, request GreetRequest) (respon
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -151,8 +151,8 @@ func (p *barPlugin) Hello(ctx context.Context, request Request) (response Reply,
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -166,10 +166,10 @@ func (p *barPlugin) Hello(ctx context.Context, request Request) (response Reply,
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -152,8 +152,8 @@ func (p *fooPlugin) Hello(ctx context.Context, request Request) (response bar.Re
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -167,10 +167,10 @@ func (p *fooPlugin) Hello(ctx context.Context, request Request) (response bar.Re
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -152,8 +152,8 @@ func (p *knownTypesTestPlugin) Test(ctx context.Context, request Request) (respo
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -167,10 +167,10 @@ func (p *knownTypesTestPlugin) Test(ctx context.Context, request Request) (respo
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {
@@ -310,8 +310,8 @@ func (p *emptyTestPlugin) DoNothing(ctx context.Context, request emptypb.Empty) 
 		defer p.free.Call(ctx, dataPtr)
 
 		// The pointer is a linear memory offset, which is where we write the name.
-		if !p.module.Memory().Write(ctx, uint32(dataPtr), data) {
-			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size(ctx))
+		if !p.module.Memory().Write(uint32(dataPtr), data) {
+			return response, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d", dataPtr, dataSize, p.module.Memory().Size())
 		}
 	}
 
@@ -325,10 +325,10 @@ func (p *emptyTestPlugin) DoNothing(ctx context.Context, request emptypb.Empty) 
 	resSize := uint32(ptrSize[0])
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	bytes, ok := p.module.Memory().Read(ctx, resPtr, resSize)
+	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
 		return response, fmt.Errorf("Memory.Read(%d, %d) out of range of memory size %d",
-			resPtr, resSize, p.module.Memory().Size(ctx))
+			resPtr, resSize, p.module.Memory().Size())
 	}
 
 	if err = response.UnmarshalVT(bytes); err != nil {

--- a/wasm/host.go
+++ b/wasm/host.go
@@ -13,7 +13,7 @@ import (
 )
 
 func ReadMemory(ctx context.Context, m api.Module, offset, size uint32) ([]byte, error) {
-	buf, ok := m.Memory().Read(ctx, offset, size)
+	buf, ok := m.Memory().Read(offset, size)
 	if !ok {
 		return nil, fmt.Errorf("Memory.Read(%d, %d) out of range", offset, size)
 	}
@@ -38,9 +38,9 @@ func WriteMemory(ctx context.Context, m api.Module, data []byte) (uint64, error)
 	dataPtr := results[0]
 
 	// The pointer is a linear memory offset, which is where we write the name.
-	if !m.Memory().Write(ctx, uint32(dataPtr), data) {
+	if !m.Memory().Write(uint32(dataPtr), data) {
 		return 0, fmt.Errorf("Memory.Write(%d, %d) out of range of memory size %d",
-			dataPtr, len(data), m.Memory().Size(ctx))
+			dataPtr, len(data), m.Memory().Size())
 	}
 
 	return dataPtr, nil


### PR DESCRIPTION
*Issue #16
*Description of changes:* https://github.com/tetratelabs/wazero/commit/126bd9050d3a1a19d74ca82f5875e5ce766fd2e8


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
