### PR TITLE
Validate plugin type presence if host function is defined

### DIFF
--- a/gen/init.go
+++ b/gen/init.go
@@ -87,6 +87,10 @@ func (gg *Generator) newFileInfo(file *protogen.File) *fileInfo {
 			}
 			f.allServices = append(f.allServices, si)
 		}
+		// If host function is defined, at least one plugin service should be present in the proto file.
+		if f.hostService != nil && len(f.pluginServices) == 0 {
+			gg.plugin.Error(errors.New("should be defined at least one type=plugin service"))
+		}
 	}
 	initEnumInfos(f.Enums)
 	initMessageInfos(f.Messages)


### PR DESCRIPTION
*Description of changes:*
If someone define host functions (type=host), but promised or missed to define service plugin (type=plugin), the output generated code will be incorrect.
Add additional validation to the plugin generator: if host function is defined, at least one plugin service should be present in the .proto file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
