### PR TITLE
Able to configure Runtime and ModuleConfig for plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ func main() {
 	ctx := context.Background()
 	
 	// Initialize a plugin loader
-	p, err := greeting.NewGreeterPlugin(ctx, greeting.GreeterPluginOption{})
+	p, err := greeting.NewGreeterPlugin(ctx)
 	if err != nil {...}
 	defer p.Close(ctx)
 
@@ -322,10 +322,11 @@ Also, you can export a host function. The example is available [here][json-examp
 `fmt.Printf` can be used in plugins if you attach `os.Stdout` as below. See [the example][wasi-example] for more details.
 
 ```Go
-p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginOption{
-	Stdout: os.Stdout, // Attach stdout so that the plugin can write outputs to stdout
-	Stderr: os.Stderr, // Attach stderr so that the plugin can write errors to stderr
-})
+mc := wazero.NewModuleConfig().
+    WithStdout(os.Stdout). // Attach stdout so that the plugin can write outputs to stdout
+    WithStderr(os.Stderr). // Attach stderr so that the plugin can write errors to stderr
+    WithFS(f)              // Loaded plugins can access only files that the host allows.
+p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginModuleConfig(mc))
 ```
 
 If you need structured and leveled logging, you can define host functions so that plugins can call those logging functions.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ mc := wazero.NewModuleConfig().
     WithStdout(os.Stdout). // Attach stdout so that the plugin can write outputs to stdout
     WithStderr(os.Stderr). // Attach stderr so that the plugin can write errors to stderr
     WithFS(f)              // Loaded plugins can access only files that the host allows.
-p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginModuleConfig(mc))
+p, err := cat.NewFileCatPlugin(ctx, options.WazeroModuleConfig(mc))
 ```
 
 If you need structured and leveled logging, you can define host functions so that plugins can call those logging functions.

--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -49,7 +49,6 @@ func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
 	}
 }
 func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &GreeterPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -16,40 +16,55 @@ import (
 	api "github.com/tetratelabs/wazero/api"
 	wasi_snapshot_preview1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	sys "github.com/tetratelabs/wazero/sys"
-	io "io"
-	fs "io/fs"
 	os "os"
 )
 
 const GreeterPluginAPIVersion = 1
 
-type GreeterPluginOption struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	FS     fs.FS
-}
+type GreeterPluginOption func(plugin *GreeterPlugin)
 
 type GreeterPlugin struct {
-	cache  wazero.CompilationCache
-	config wazero.ModuleConfig
+	newRuntime   func(context.Context) (wazero.Runtime, error)
+	cache        wazero.CompilationCache
+	moduleConfig wazero.ModuleConfig
 }
 
-func NewGreeterPlugin(ctx context.Context, opt GreeterPluginOption) (*GreeterPlugin, error) {
+type GreeterPluginNewRuntime func(context.Context) (wazero.Runtime, error)
 
-	// Create a new WebAssembly CompilationCache.
+func GreeterPluginRuntime(newRuntime GreeterPluginNewRuntime) GreeterPluginOption {
+	return func(h *GreeterPlugin) {
+		h.newRuntime = newRuntime
+	}
+}
+
+func GreeterPluginModuleConfig(moduleConfig wazero.ModuleConfig) GreeterPluginOption {
+	return func(h *GreeterPlugin) {
+		h.moduleConfig = moduleConfig
+	}
+}
+
+func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
+	return func(h *GreeterPlugin) {
+		h.cache = cache
+	}
+}
+func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
+
 	cache := wazero.NewCompilationCache()
+	o := &GreeterPlugin{
+		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
+			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
+		},
+		cache:        cache,
+		moduleConfig: wazero.NewModuleConfig(),
+	}
 
-	// Combine the above into our baseline config, overriding defaults.
-	config := wazero.NewModuleConfig().
-		// By default, I/O streams are discarded and there's no file system.
-		WithStdout(opt.Stdout).WithStderr(opt.Stderr).WithFS(opt.FS)
+	for _, opt := range opts {
+		opt(o)
+	}
 
-	return &GreeterPlugin{
-		cache:  cache,
-		config: config,
-	}, nil
+	return o, nil
 }
-
 func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
 	if c := p.cache; c != nil {
 		err = c.Close(ctx)
@@ -63,8 +78,11 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string) (Greeter, e
 		return nil, err
 	}
 
-	// Create an empty namespace so that multiple modules will not conflict
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(p.cache))
+	// Create a new runtime so that multiple modules will not conflict
+	r, err := p.newRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err
@@ -77,7 +95,7 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string) (Greeter, e
 	}
 
 	// InstantiateModule runs the "_start" function, WASI's "main".
-	module, err := r.InstantiateModule(ctx, code, p.config)
+	module, err := r.InstantiateModule(ctx, code, p.moduleConfig)
 	if err != nil {
 		// Note: Most compilers do not exit the module after running "_start",
 		// unless there was an Error. This allows you to call exported functions.

--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -27,6 +27,7 @@ type GreeterPluginOption func(plugin *GreeterPlugin)
 type GreeterPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
 	moduleConfig wazero.ModuleConfig
+	runtimes     []wazero.Runtime
 }
 
 func NewGreeterPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*GreeterPlugin, error) {
@@ -41,7 +42,13 @@ func NewGreeterPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (
 		moduleConfig: o.ModuleConfig,
 	}, nil
 }
+
 func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
+	for i := range p.runtimes {
+		if r := p.runtimes[i]; r != nil {
+			err = r.Close(ctx)
+		}
+	}
 	return
 }
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string) (Greeter, error) {
@@ -55,6 +62,7 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string) (Greeter, e
 	if err != nil {
 		return nil, err
 	}
+	p.runtimes = append(p.runtimes, r)
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err

--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -51,6 +51,7 @@ func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string) (Greeter, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -16,7 +16,7 @@ func main() {
 
 func run() error {
 	ctx := context.Background()
-	p, err := greeting.NewGreeterPlugin(ctx, greeting.GreeterPluginOption{})
+	p, err := greeting.NewGreeterPlugin(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/host-functions/README.md
+++ b/examples/host-functions/README.md
@@ -67,7 +67,7 @@ Pass it to a plugin in `Load()`.
 
 ```go
 // Pass my host functions that are embedded into the plugin.
-greetingPlugin, err := p.Load(ctx, "plugin/plugin.wasm", myHostFunctions{})
+greetingPlugin, err := p.Load(ctx, "plugin/plugin.wasm")
 ```
 
 ## Call host functions in a plugin

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -17,8 +17,6 @@ import (
 	api "github.com/tetratelabs/wazero/api"
 	wasi_snapshot_preview1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	sys "github.com/tetratelabs/wazero/sys"
-	io "io"
-	fs "io/fs"
 	os "os"
 )
 
@@ -109,33 +107,50 @@ func (h _hostFunctions) _Log(ctx context.Context, m api.Module, stack []uint64) 
 
 const GreeterPluginAPIVersion = 1
 
-type GreeterPluginOption struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	FS     fs.FS
-}
+type GreeterPluginOption func(plugin *GreeterPlugin)
 
 type GreeterPlugin struct {
-	cache  wazero.CompilationCache
-	config wazero.ModuleConfig
+	newRuntime   func(context.Context) (wazero.Runtime, error)
+	cache        wazero.CompilationCache
+	moduleConfig wazero.ModuleConfig
 }
 
-func NewGreeterPlugin(ctx context.Context, opt GreeterPluginOption) (*GreeterPlugin, error) {
+type GreeterPluginNewRuntime func(context.Context) (wazero.Runtime, error)
 
-	// Create a new WebAssembly CompilationCache.
+func GreeterPluginRuntime(newRuntime GreeterPluginNewRuntime) GreeterPluginOption {
+	return func(h *GreeterPlugin) {
+		h.newRuntime = newRuntime
+	}
+}
+
+func GreeterPluginModuleConfig(moduleConfig wazero.ModuleConfig) GreeterPluginOption {
+	return func(h *GreeterPlugin) {
+		h.moduleConfig = moduleConfig
+	}
+}
+
+func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
+	return func(h *GreeterPlugin) {
+		h.cache = cache
+	}
+}
+func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
+
 	cache := wazero.NewCompilationCache()
+	o := &GreeterPlugin{
+		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
+			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
+		},
+		cache:        cache,
+		moduleConfig: wazero.NewModuleConfig(),
+	}
 
-	// Combine the above into our baseline config, overriding defaults.
-	config := wazero.NewModuleConfig().
-		// By default, I/O streams are discarded and there's no file system.
-		WithStdout(opt.Stdout).WithStderr(opt.Stderr).WithFS(opt.FS)
+	for _, opt := range opts {
+		opt(o)
+	}
 
-	return &GreeterPlugin{
-		cache:  cache,
-		config: config,
-	}, nil
+	return o, nil
 }
-
 func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
 	if c := p.cache; c != nil {
 		err = c.Close(ctx)
@@ -149,8 +164,11 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctio
 		return nil, err
 	}
 
-	// Create an empty namespace so that multiple modules will not conflict
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(p.cache))
+	// Create a new runtime so that multiple modules will not conflict
+	r, err := p.newRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	h := _hostFunctions{hostFunctions}
 
@@ -169,7 +187,7 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctio
 	}
 
 	// InstantiateModule runs the "_start" function, WASI's "main".
-	module, err := r.InstantiateModule(ctx, code, p.config)
+	module, err := r.InstantiateModule(ctx, code, p.moduleConfig)
 	if err != nil {
 		// Note: Most compilers do not exit the module after running "_start",
 		// unless there was an Error. This allows you to call exported functions.

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -135,7 +135,6 @@ func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
 	}
 }
 func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &GreeterPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -137,6 +137,7 @@ func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctions HostFunctions) (Greeter, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -113,6 +113,7 @@ type GreeterPluginOption func(plugin *GreeterPlugin)
 type GreeterPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
 	moduleConfig wazero.ModuleConfig
+	runtimes     []wazero.Runtime
 }
 
 func NewGreeterPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*GreeterPlugin, error) {
@@ -127,7 +128,13 @@ func NewGreeterPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (
 		moduleConfig: o.ModuleConfig,
 	}, nil
 }
+
 func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
+	for i := range p.runtimes {
+		if r := p.runtimes[i]; r != nil {
+			err = r.Close(ctx)
+		}
+	}
 	return
 }
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctions HostFunctions) (Greeter, error) {
@@ -141,6 +148,7 @@ func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctio
 	if err != nil {
 		return nil, err
 	}
+	p.runtimes = append(p.runtimes, r)
 
 	h := _hostFunctions{hostFunctions}
 

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -12,6 +12,7 @@ import (
 	context "context"
 	errors "errors"
 	fmt "fmt"
+	options "github.com/knqyf263/go-plugin/options"
 	wasm "github.com/knqyf263/go-plugin/wasm"
 	wazero "github.com/tetratelabs/wazero"
 	api "github.com/tetratelabs/wazero/api"
@@ -111,52 +112,24 @@ type GreeterPluginOption func(plugin *GreeterPlugin)
 
 type GreeterPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
-	cache        wazero.CompilationCache
 	moduleConfig wazero.ModuleConfig
 }
 
-type GreeterPluginNewRuntime func(context.Context) (wazero.Runtime, error)
-
-func GreeterPluginRuntime(newRuntime GreeterPluginNewRuntime) GreeterPluginOption {
-	return func(h *GreeterPlugin) {
-		h.newRuntime = newRuntime
-	}
-}
-
-func GreeterPluginModuleConfig(moduleConfig wazero.ModuleConfig) GreeterPluginOption {
-	return func(h *GreeterPlugin) {
-		h.moduleConfig = moduleConfig
-	}
-}
-
-func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
-	return func(h *GreeterPlugin) {
-		h.cache = cache
-	}
-}
-func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
-	cache := wazero.NewCompilationCache()
-	o := &GreeterPlugin{
-		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
-			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
-		},
-		cache:        cache,
-		moduleConfig: wazero.NewModuleConfig(),
-	}
+func NewGreeterPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*GreeterPlugin, error) {
+	o := options.NewWazeroConfig()
 
 	for _, opt := range opts {
 		opt(o)
 	}
 
-	return o, nil
+	return &GreeterPlugin{
+		newRuntime:   o.NewRuntime,
+		moduleConfig: o.ModuleConfig,
+	}, nil
 }
 func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
-	if c := p.cache; c != nil {
-		err = c.Close(ctx)
-	}
 	return
 }
-
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctions HostFunctions) (Greeter, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/examples/host-functions/main.go
+++ b/examples/host-functions/main.go
@@ -19,7 +19,7 @@ func main() {
 
 func run() error {
 	ctx := context.Background()
-	p, err := greeting.NewGreeterPlugin(ctx, greeting.GreeterPluginOption{})
+	p, err := greeting.NewGreeterPlugin(ctx)
 	if err != nil {
 		return err
 	}

--- a/examples/known-types/known/known_host.pb.go
+++ b/examples/known-types/known/known_host.pb.go
@@ -49,7 +49,6 @@ func WellKnownPluginCache(cache wazero.CompilationCache) WellKnownPluginOption {
 	}
 }
 func NewWellKnownPlugin(ctx context.Context, opts ...WellKnownPluginOption) (*WellKnownPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &WellKnownPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/examples/known-types/known/known_host.pb.go
+++ b/examples/known-types/known/known_host.pb.go
@@ -51,6 +51,7 @@ func (p *WellKnownPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *WellKnownPlugin) Load(ctx context.Context, pluginPath string) (WellKnown, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/examples/known-types/main.go
+++ b/examples/known-types/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"log"
 	"os"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/tetratelabs/wazero"
 
 	"github.com/knqyf263/go-plugin/examples/known-types/known"
+	"github.com/knqyf263/go-plugin/options"
 	"github.com/knqyf263/go-plugin/types/known/structpb"
 	"github.com/knqyf263/go-plugin/types/known/timestamppb"
 )
@@ -23,7 +25,7 @@ func main() {
 func run() error {
 	ctx := context.Background()
 	mc := wazero.NewModuleConfig().WithStdout(os.Stdout).WithStderr(os.Stderr)
-	p, err := known.NewWellKnownPlugin(ctx, known.WellKnownPluginModuleConfig(mc))
+	p, err := known.NewWellKnownPlugin(ctx, options.WazeroModuleConfig(mc))
 	if err != nil {
 		return err
 	}

--- a/examples/known-types/main.go
+++ b/examples/known-types/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-
 	"log"
 	"os"
 	"time"

--- a/examples/known-types/main.go
+++ b/examples/known-types/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/tetratelabs/wazero"
+
 	"github.com/knqyf263/go-plugin/examples/known-types/known"
 	"github.com/knqyf263/go-plugin/types/known/structpb"
 	"github.com/knqyf263/go-plugin/types/known/timestamppb"
@@ -20,7 +22,8 @@ func main() {
 
 func run() error {
 	ctx := context.Background()
-	p, err := known.NewWellKnownPlugin(ctx, known.WellKnownPluginOption{Stdout: os.Stdout, Stderr: os.Stderr})
+	mc := wazero.NewModuleConfig().WithStdout(os.Stdout).WithStderr(os.Stderr)
+	p, err := known.NewWellKnownPlugin(ctx, known.WellKnownPluginModuleConfig(mc))
 	if err != nil {
 		return err
 	}

--- a/examples/wasi/README.md
+++ b/examples/wasi/README.md
@@ -17,11 +17,11 @@ var f embed.FS
 
 func run() error {
         ctx := context.Background()
-        p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginOption{
-                Stdout: os.Stdout, // Attach stdout so that the plugin can write outputs to stdout
-                Stderr: os.Stderr, // Attach stderr so that the plugin can write errors to stderr
-                FS:     f,         // Loaded plugins can access only files that the host allows.
-        })
+		mc := wazero.NewModuleConfig().
+            WithStdout(os.Stdout). // Attach stdout so that the plugin can write outputs to stdout
+            WithStderr(os.Stderr). // Attach stderr so that the plugin can write errors to stderr
+            WithFS(f)              // Loaded plugins can access only files that the host allows.
+        p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginModuleConfig(mc))
 ```
 
 In this example, the host just passes `testdata/hello.txt` via `FileCatPluginOption`, but you can pass whatever you want.

--- a/examples/wasi/README.md
+++ b/examples/wasi/README.md
@@ -12,7 +12,12 @@ $ protoc --go-plugin_out=. --go-plugin_opt=paths=source_relative cat/cat.proto
 A host can control which files/dirs plugins can access.
 
 ```go
+import (
+    "github.com/knqyf263/go-plugin/options"
+)
+
 //go:embed testdata/hello.txt
+
 var f embed.FS
 
 func run() error {
@@ -21,7 +26,7 @@ func run() error {
             WithStdout(os.Stdout). // Attach stdout so that the plugin can write outputs to stdout
             WithStderr(os.Stderr). // Attach stderr so that the plugin can write errors to stderr
             WithFS(f)              // Loaded plugins can access only files that the host allows.
-        p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginModuleConfig(mc))
+        p, err := cat.NewFileCatPlugin(ctx, options.WazeroModuleConfig(mc))
 ```
 
 In this example, the host just passes `testdata/hello.txt` via `FileCatPluginOption`, but you can pass whatever you want.

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -49,7 +49,6 @@ func FileCatPluginCache(cache wazero.CompilationCache) FileCatPluginOption {
 	}
 }
 func NewFileCatPlugin(ctx context.Context, opts ...FileCatPluginOption) (*FileCatPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &FileCatPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -16,40 +16,55 @@ import (
 	api "github.com/tetratelabs/wazero/api"
 	wasi_snapshot_preview1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	sys "github.com/tetratelabs/wazero/sys"
-	io "io"
-	fs "io/fs"
 	os "os"
 )
 
 const FileCatPluginAPIVersion = 1
 
-type FileCatPluginOption struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	FS     fs.FS
-}
+type FileCatPluginOption func(plugin *FileCatPlugin)
 
 type FileCatPlugin struct {
-	cache  wazero.CompilationCache
-	config wazero.ModuleConfig
+	newRuntime   func(context.Context) (wazero.Runtime, error)
+	cache        wazero.CompilationCache
+	moduleConfig wazero.ModuleConfig
 }
 
-func NewFileCatPlugin(ctx context.Context, opt FileCatPluginOption) (*FileCatPlugin, error) {
+type FileCatPluginNewRuntime func(context.Context) (wazero.Runtime, error)
 
-	// Create a new WebAssembly CompilationCache.
+func FileCatPluginRuntime(newRuntime FileCatPluginNewRuntime) FileCatPluginOption {
+	return func(h *FileCatPlugin) {
+		h.newRuntime = newRuntime
+	}
+}
+
+func FileCatPluginModuleConfig(moduleConfig wazero.ModuleConfig) FileCatPluginOption {
+	return func(h *FileCatPlugin) {
+		h.moduleConfig = moduleConfig
+	}
+}
+
+func FileCatPluginCache(cache wazero.CompilationCache) FileCatPluginOption {
+	return func(h *FileCatPlugin) {
+		h.cache = cache
+	}
+}
+func NewFileCatPlugin(ctx context.Context, opts ...FileCatPluginOption) (*FileCatPlugin, error) {
+
 	cache := wazero.NewCompilationCache()
+	o := &FileCatPlugin{
+		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
+			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
+		},
+		cache:        cache,
+		moduleConfig: wazero.NewModuleConfig(),
+	}
 
-	// Combine the above into our baseline config, overriding defaults.
-	config := wazero.NewModuleConfig().
-		// By default, I/O streams are discarded and there's no file system.
-		WithStdout(opt.Stdout).WithStderr(opt.Stderr).WithFS(opt.FS)
+	for _, opt := range opts {
+		opt(o)
+	}
 
-	return &FileCatPlugin{
-		cache:  cache,
-		config: config,
-	}, nil
+	return o, nil
 }
-
 func (p *FileCatPlugin) Close(ctx context.Context) (err error) {
 	if c := p.cache; c != nil {
 		err = c.Close(ctx)
@@ -63,8 +78,11 @@ func (p *FileCatPlugin) Load(ctx context.Context, pluginPath string) (FileCat, e
 		return nil, err
 	}
 
-	// Create an empty namespace so that multiple modules will not conflict
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(p.cache))
+	// Create a new runtime so that multiple modules will not conflict
+	r, err := p.newRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err
@@ -77,7 +95,7 @@ func (p *FileCatPlugin) Load(ctx context.Context, pluginPath string) (FileCat, e
 	}
 
 	// InstantiateModule runs the "_start" function, WASI's "main".
-	module, err := r.InstantiateModule(ctx, code, p.config)
+	module, err := r.InstantiateModule(ctx, code, p.moduleConfig)
 	if err != nil {
 		// Note: Most compilers do not exit the module after running "_start",
 		// unless there was an Error. This allows you to call exported functions.

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -51,6 +51,7 @@ func (p *FileCatPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *FileCatPlugin) Load(ctx context.Context, pluginPath string) (FileCat, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/examples/wasi/main.go
+++ b/examples/wasi/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tetratelabs/wazero"
 
 	"github.com/knqyf263/go-plugin/examples/wasi/cat"
+	"github.com/knqyf263/go-plugin/options"
 )
 
 //go:embed testdata/hello.txt
@@ -28,7 +29,7 @@ func run() error {
 		WithStdout(os.Stdout). // Attach stdout so that the plugin can write outputs to stdout
 		WithStderr(os.Stderr). // Attach stderr so that the plugin can write errors to stderr
 		WithFS(f)              // Loaded plugins can access only files that the host allows.
-	p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginModuleConfig(mc))
+	p, err := cat.NewFileCatPlugin(ctx, options.WazeroModuleConfig(mc))
 	if err != nil {
 		return err
 	}

--- a/examples/wasi/main.go
+++ b/examples/wasi/main.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/tetratelabs/wazero"
+
 	"github.com/knqyf263/go-plugin/examples/wasi/cat"
 )
 
@@ -22,11 +24,11 @@ func main() {
 
 func run() error {
 	ctx := context.Background()
-	p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginOption{
-		Stdout: os.Stdout, // Attach stdout so that the plugin can write outputs to stdout
-		Stderr: os.Stderr, // Attach stderr so that the plugin can write errors to stderr
-		FS:     f,         // Loaded plugins can access only files that the host allows.
-	})
+	mc := wazero.NewModuleConfig().
+		WithStdout(os.Stdout). // Attach stdout so that the plugin can write outputs to stdout
+		WithStderr(os.Stderr). // Attach stderr so that the plugin can write errors to stderr
+		WithFS(f)              // Loaded plugins can access only files that the host allows.
+	p, err := cat.NewFileCatPlugin(ctx, cat.FileCatPluginModuleConfig(mc))
 	if err != nil {
 		return err
 	}

--- a/gen/host.go
+++ b/gen/host.go
@@ -167,8 +167,7 @@ func genHost(g *protogen.GeneratedFile, f *fileInfo, service *serviceInfo) {
 		pluginName,
 		pluginName,
 	))
-	g.P(fmt.Sprintf(`
-			cache := %s()
+	g.P(fmt.Sprintf(`cache := %s()
 			o := &%s{
 				newRuntime: func(ctx %s) (%s, error) {
 					return %s(ctx, %s().WithCompilationCache(cache)), nil

--- a/gen/host.go
+++ b/gen/host.go
@@ -118,7 +118,7 @@ func genHost(g *protogen.GeneratedFile, f *fileInfo, service *serviceInfo) {
 		pluginName,
 		g.QualifiedGoIdent(contextPackage.Ident("Context")),
 		g.QualifiedGoIdent(wazeroPackage.Ident("Runtime")),
-		g.QualifiedGoIdent(wazeroPackage.Ident("CompilationCache")),
+		g.QualifiedGoIdent(wazeroPackage.Ident("ModuleConfig")),
 	))
 
 	g.P(fmt.Sprintf(

--- a/gen/host.go
+++ b/gen/host.go
@@ -154,7 +154,8 @@ func genHost(g *protogen.GeneratedFile, f *fileInfo, service *serviceInfo) {
 			}
 		}
 		return
-	}`,
+	}
+	`,
 		pluginName,
 		g.QualifiedGoIdent(contextPackage.Ident("Context")),
 	))

--- a/gen/host.go
+++ b/gen/host.go
@@ -161,7 +161,7 @@ func genHost(g *protogen.GeneratedFile, f *fileInfo, service *serviceInfo) {
 	}
 
 	g.P(fmt.Sprintf(
-		"func New%s(ctx %s, opt ...%sOption) (*%s, error) {",
+		"func New%s(ctx %s, opts ...%sOption) (*%s, error) {",
 		pluginName,
 		g.QualifiedGoIdent(contextPackage.Ident("Context")),
 		pluginName,

--- a/gen/main.go
+++ b/gen/main.go
@@ -76,7 +76,8 @@ var (
 	wazeroSysPackage  goImportPath = protogen.GoImportPath("github.com/tetratelabs/wazero/sys")
 	wazeroWasiPackage goImportPath = protogen.GoImportPath("github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1")
 
-	pluginWasmPackage goImportPath = protogen.GoImportPath("github.com/knqyf263/go-plugin/wasm")
+	pluginWasmPackage    goImportPath = protogen.GoImportPath("github.com/knqyf263/go-plugin/wasm")
+	pluginOptionsPackage goImportPath = protogen.GoImportPath("github.com/knqyf263/go-plugin/options")
 )
 
 type goImportPath interface {

--- a/options/options.go
+++ b/options/options.go
@@ -1,0 +1,37 @@
+package options
+
+import (
+	"context"
+
+	"github.com/tetratelabs/wazero"
+)
+
+type WazeroConfigOption func(plugin *WazeroConfig)
+
+type WazeroNewRuntime func(context.Context) (wazero.Runtime, error)
+
+type WazeroConfig struct {
+	NewRuntime   func(context.Context) (wazero.Runtime, error)
+	ModuleConfig wazero.ModuleConfig
+}
+
+func NewWazeroConfig() *WazeroConfig {
+	return &WazeroConfig{
+		NewRuntime: func(ctx context.Context) (wazero.Runtime, error) {
+			return wazero.NewRuntime(ctx), nil
+		},
+		ModuleConfig: wazero.NewModuleConfig(),
+	}
+}
+
+func WazeroRuntime(newRuntime WazeroNewRuntime) WazeroConfigOption {
+	return func(h *WazeroConfig) {
+		h.NewRuntime = newRuntime
+	}
+}
+
+func WazeroModuleConfig(moduleConfig wazero.ModuleConfig) WazeroConfigOption {
+	return func(h *WazeroConfig) {
+		h.ModuleConfig = moduleConfig
+	}
+}

--- a/tests/fields/fields_test.go
+++ b/tests/fields/fields_test.go
@@ -96,7 +96,7 @@ func TestErrorResponse(t *testing.T) {
 }
 
 func loadPlugin(ctx context.Context, t *testing.T) proto.FieldTest {
-	p, err := proto.NewFieldTestPlugin(ctx, proto.FieldTestPluginOption{})
+	p, err := proto.NewFieldTestPlugin(ctx)
 	require.NoError(t, err)
 	defer p.Close(ctx)
 

--- a/tests/fields/fields_test.go
+++ b/tests/fields/fields_test.go
@@ -13,7 +13,12 @@ import (
 
 func TestFields(t *testing.T) {
 	ctx := context.Background()
-	plugin := loadPlugin(ctx, t)
+	p, err := proto.NewFieldTestPlugin(ctx)
+	require.NoError(t, err)
+	defer p.Close(ctx)
+
+	plugin, err := p.Load(ctx, "plugin/plugin.wasm")
+	require.NoError(t, err)
 
 	res, err := plugin.TestEmptyInput(ctx, emptypb.Empty{})
 	require.NoError(t, err)
@@ -75,7 +80,12 @@ func TestFields(t *testing.T) {
 
 func TestErrorResponse(t *testing.T) {
 	ctx := context.Background()
-	plugin := loadPlugin(ctx, t)
+	p, err := proto.NewFieldTestPlugin(ctx)
+	require.NoError(t, err)
+	defer p.Close(ctx)
+
+	plugin, err := p.Load(ctx, "plugin/plugin.wasm")
+	require.NoError(t, err)
 
 	for _, tt := range []struct {
 		name       string
@@ -93,15 +103,4 @@ func TestErrorResponse(t *testing.T) {
 			require.Equal(t, err.Error(), tt.errMessage)
 		})
 	}
-}
-
-func loadPlugin(ctx context.Context, t *testing.T) proto.FieldTest {
-	p, err := proto.NewFieldTestPlugin(ctx)
-	require.NoError(t, err)
-	defer p.Close(ctx)
-
-	plugin, err := p.Load(ctx, "plugin/plugin.wasm")
-	require.NoError(t, err)
-
-	return plugin
 }

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -52,6 +52,7 @@ func (p *FieldTestPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *FieldTestPlugin) Load(ctx context.Context, pluginPath string) (FieldTest, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -50,7 +50,6 @@ func FieldTestPluginCache(cache wazero.CompilationCache) FieldTestPluginOption {
 	}
 }
 func NewFieldTestPlugin(ctx context.Context, opts ...FieldTestPluginOption) (*FieldTestPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &FieldTestPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/tests/host-functions/host_functions_test.go
+++ b/tests/host-functions/host_functions_test.go
@@ -8,13 +8,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/wazero"
 
 	"github.com/knqyf263/go-plugin/tests/host-functions/proto"
 )
 
 func TestHostFunctions(t *testing.T) {
 	ctx := context.Background()
-	p, err := proto.NewGreeterPlugin(ctx, proto.GreeterPluginOption{Stdout: os.Stdout})
+	mc := wazero.NewModuleConfig().WithStdout(os.Stdout)
+	p, err := proto.NewGreeterPlugin(ctx, proto.GreeterPluginModuleConfig(mc))
 	require.NoError(t, err)
 	defer p.Close(ctx)
 

--- a/tests/host-functions/host_functions_test.go
+++ b/tests/host-functions/host_functions_test.go
@@ -10,13 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tetratelabs/wazero"
 
+	"github.com/knqyf263/go-plugin/options"
 	"github.com/knqyf263/go-plugin/tests/host-functions/proto"
 )
 
 func TestHostFunctions(t *testing.T) {
 	ctx := context.Background()
 	mc := wazero.NewModuleConfig().WithStdout(os.Stdout)
-	p, err := proto.NewGreeterPlugin(ctx, proto.GreeterPluginModuleConfig(mc))
+	p, err := proto.NewGreeterPlugin(ctx, options.WazeroModuleConfig(mc))
 	require.NoError(t, err)
 	defer p.Close(ctx)
 

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -99,7 +99,6 @@ func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
 	}
 }
 func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &GreeterPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -101,6 +101,7 @@ func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctions HostFunctions) (Greeter, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -12,6 +12,7 @@ import (
 	context "context"
 	errors "errors"
 	fmt "fmt"
+	options "github.com/knqyf263/go-plugin/options"
 	wasm "github.com/knqyf263/go-plugin/wasm"
 	wazero "github.com/tetratelabs/wazero"
 	api "github.com/tetratelabs/wazero/api"
@@ -75,52 +76,24 @@ type GreeterPluginOption func(plugin *GreeterPlugin)
 
 type GreeterPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
-	cache        wazero.CompilationCache
 	moduleConfig wazero.ModuleConfig
 }
 
-type GreeterPluginNewRuntime func(context.Context) (wazero.Runtime, error)
-
-func GreeterPluginRuntime(newRuntime GreeterPluginNewRuntime) GreeterPluginOption {
-	return func(h *GreeterPlugin) {
-		h.newRuntime = newRuntime
-	}
-}
-
-func GreeterPluginModuleConfig(moduleConfig wazero.ModuleConfig) GreeterPluginOption {
-	return func(h *GreeterPlugin) {
-		h.moduleConfig = moduleConfig
-	}
-}
-
-func GreeterPluginCache(cache wazero.CompilationCache) GreeterPluginOption {
-	return func(h *GreeterPlugin) {
-		h.cache = cache
-	}
-}
-func NewGreeterPlugin(ctx context.Context, opts ...GreeterPluginOption) (*GreeterPlugin, error) {
-	cache := wazero.NewCompilationCache()
-	o := &GreeterPlugin{
-		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
-			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
-		},
-		cache:        cache,
-		moduleConfig: wazero.NewModuleConfig(),
-	}
+func NewGreeterPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*GreeterPlugin, error) {
+	o := options.NewWazeroConfig()
 
 	for _, opt := range opts {
 		opt(o)
 	}
 
-	return o, nil
+	return &GreeterPlugin{
+		newRuntime:   o.NewRuntime,
+		moduleConfig: o.ModuleConfig,
+	}, nil
 }
 func (p *GreeterPlugin) Close(ctx context.Context) (err error) {
-	if c := p.cache; c != nil {
-		err = c.Close(ctx)
-	}
 	return
 }
-
 func (p *GreeterPlugin) Load(ctx context.Context, pluginPath string, hostFunctions HostFunctions) (Greeter, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/import/import_test.go
+++ b/tests/import/import_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestImport(t *testing.T) {
 	ctx := context.Background()
-	p, err := foo.NewFooPlugin(ctx, foo.FooPluginOption{})
+	p, err := foo.NewFooPlugin(ctx)
 	require.NoError(t, err)
 	defer p.Close(ctx)
 

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -49,7 +49,6 @@ func BarPluginCache(cache wazero.CompilationCache) BarPluginOption {
 	}
 }
 func NewBarPlugin(ctx context.Context, opts ...BarPluginOption) (*BarPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &BarPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -51,6 +51,7 @@ func (p *BarPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *BarPlugin) Load(ctx context.Context, pluginPath string) (Bar, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -16,40 +16,55 @@ import (
 	api "github.com/tetratelabs/wazero/api"
 	wasi_snapshot_preview1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	sys "github.com/tetratelabs/wazero/sys"
-	io "io"
-	fs "io/fs"
 	os "os"
 )
 
 const BarPluginAPIVersion = 1
 
-type BarPluginOption struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	FS     fs.FS
-}
+type BarPluginOption func(plugin *BarPlugin)
 
 type BarPlugin struct {
-	cache  wazero.CompilationCache
-	config wazero.ModuleConfig
+	newRuntime   func(context.Context) (wazero.Runtime, error)
+	cache        wazero.CompilationCache
+	moduleConfig wazero.ModuleConfig
 }
 
-func NewBarPlugin(ctx context.Context, opt BarPluginOption) (*BarPlugin, error) {
+type BarPluginNewRuntime func(context.Context) (wazero.Runtime, error)
 
-	// Create a new WebAssembly CompilationCache.
+func BarPluginRuntime(newRuntime BarPluginNewRuntime) BarPluginOption {
+	return func(h *BarPlugin) {
+		h.newRuntime = newRuntime
+	}
+}
+
+func BarPluginModuleConfig(moduleConfig wazero.ModuleConfig) BarPluginOption {
+	return func(h *BarPlugin) {
+		h.moduleConfig = moduleConfig
+	}
+}
+
+func BarPluginCache(cache wazero.CompilationCache) BarPluginOption {
+	return func(h *BarPlugin) {
+		h.cache = cache
+	}
+}
+func NewBarPlugin(ctx context.Context, opts ...BarPluginOption) (*BarPlugin, error) {
+
 	cache := wazero.NewCompilationCache()
+	o := &BarPlugin{
+		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
+			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
+		},
+		cache:        cache,
+		moduleConfig: wazero.NewModuleConfig(),
+	}
 
-	// Combine the above into our baseline config, overriding defaults.
-	config := wazero.NewModuleConfig().
-		// By default, I/O streams are discarded and there's no file system.
-		WithStdout(opt.Stdout).WithStderr(opt.Stderr).WithFS(opt.FS)
+	for _, opt := range opts {
+		opt(o)
+	}
 
-	return &BarPlugin{
-		cache:  cache,
-		config: config,
-	}, nil
+	return o, nil
 }
-
 func (p *BarPlugin) Close(ctx context.Context) (err error) {
 	if c := p.cache; c != nil {
 		err = c.Close(ctx)
@@ -63,8 +78,11 @@ func (p *BarPlugin) Load(ctx context.Context, pluginPath string) (Bar, error) {
 		return nil, err
 	}
 
-	// Create an empty namespace so that multiple modules will not conflict
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(p.cache))
+	// Create a new runtime so that multiple modules will not conflict
+	r, err := p.newRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err
@@ -77,7 +95,7 @@ func (p *BarPlugin) Load(ctx context.Context, pluginPath string) (Bar, error) {
 	}
 
 	// InstantiateModule runs the "_start" function, WASI's "main".
-	module, err := r.InstantiateModule(ctx, code, p.config)
+	module, err := r.InstantiateModule(ctx, code, p.moduleConfig)
 	if err != nil {
 		// Note: Most compilers do not exit the module after running "_start",
 		// unless there was an Error. This allows you to call exported functions.

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -27,6 +27,7 @@ type BarPluginOption func(plugin *BarPlugin)
 type BarPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
 	moduleConfig wazero.ModuleConfig
+	runtimes     []wazero.Runtime
 }
 
 func NewBarPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*BarPlugin, error) {
@@ -41,7 +42,13 @@ func NewBarPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*Bar
 		moduleConfig: o.ModuleConfig,
 	}, nil
 }
+
 func (p *BarPlugin) Close(ctx context.Context) (err error) {
+	for i := range p.runtimes {
+		if r := p.runtimes[i]; r != nil {
+			err = r.Close(ctx)
+		}
+	}
 	return
 }
 func (p *BarPlugin) Load(ctx context.Context, pluginPath string) (Bar, error) {
@@ -55,6 +62,7 @@ func (p *BarPlugin) Load(ctx context.Context, pluginPath string) (Bar, error) {
 	if err != nil {
 		return nil, err
 	}
+	p.runtimes = append(p.runtimes, r)
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -17,40 +17,55 @@ import (
 	api "github.com/tetratelabs/wazero/api"
 	wasi_snapshot_preview1 "github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	sys "github.com/tetratelabs/wazero/sys"
-	io "io"
-	fs "io/fs"
 	os "os"
 )
 
 const FooPluginAPIVersion = 1
 
-type FooPluginOption struct {
-	Stdout io.Writer
-	Stderr io.Writer
-	FS     fs.FS
-}
+type FooPluginOption func(plugin *FooPlugin)
 
 type FooPlugin struct {
-	cache  wazero.CompilationCache
-	config wazero.ModuleConfig
+	newRuntime   func(context.Context) (wazero.Runtime, error)
+	cache        wazero.CompilationCache
+	moduleConfig wazero.ModuleConfig
 }
 
-func NewFooPlugin(ctx context.Context, opt FooPluginOption) (*FooPlugin, error) {
+type FooPluginNewRuntime func(context.Context) (wazero.Runtime, error)
 
-	// Create a new WebAssembly CompilationCache.
+func FooPluginRuntime(newRuntime FooPluginNewRuntime) FooPluginOption {
+	return func(h *FooPlugin) {
+		h.newRuntime = newRuntime
+	}
+}
+
+func FooPluginModuleConfig(moduleConfig wazero.ModuleConfig) FooPluginOption {
+	return func(h *FooPlugin) {
+		h.moduleConfig = moduleConfig
+	}
+}
+
+func FooPluginCache(cache wazero.CompilationCache) FooPluginOption {
+	return func(h *FooPlugin) {
+		h.cache = cache
+	}
+}
+func NewFooPlugin(ctx context.Context, opts ...FooPluginOption) (*FooPlugin, error) {
+
 	cache := wazero.NewCompilationCache()
+	o := &FooPlugin{
+		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
+			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
+		},
+		cache:        cache,
+		moduleConfig: wazero.NewModuleConfig(),
+	}
 
-	// Combine the above into our baseline config, overriding defaults.
-	config := wazero.NewModuleConfig().
-		// By default, I/O streams are discarded and there's no file system.
-		WithStdout(opt.Stdout).WithStderr(opt.Stderr).WithFS(opt.FS)
+	for _, opt := range opts {
+		opt(o)
+	}
 
-	return &FooPlugin{
-		cache:  cache,
-		config: config,
-	}, nil
+	return o, nil
 }
-
 func (p *FooPlugin) Close(ctx context.Context) (err error) {
 	if c := p.cache; c != nil {
 		err = c.Close(ctx)
@@ -64,8 +79,11 @@ func (p *FooPlugin) Load(ctx context.Context, pluginPath string) (Foo, error) {
 		return nil, err
 	}
 
-	// Create an empty namespace so that multiple modules will not conflict
-	r := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(p.cache))
+	// Create a new runtime so that multiple modules will not conflict
+	r, err := p.newRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err
@@ -78,7 +96,7 @@ func (p *FooPlugin) Load(ctx context.Context, pluginPath string) (Foo, error) {
 	}
 
 	// InstantiateModule runs the "_start" function, WASI's "main".
-	module, err := r.InstantiateModule(ctx, code, p.config)
+	module, err := r.InstantiateModule(ctx, code, p.moduleConfig)
 	if err != nil {
 		// Note: Most compilers do not exit the module after running "_start",
 		// unless there was an Error. This allows you to call exported functions.

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -52,6 +52,7 @@ func (p *FooPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *FooPlugin) Load(ctx context.Context, pluginPath string) (Foo, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -50,7 +50,6 @@ func FooPluginCache(cache wazero.CompilationCache) FooPluginOption {
 	}
 }
 func NewFooPlugin(ctx context.Context, opts ...FooPluginOption) (*FooPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &FooPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -50,7 +50,6 @@ func KnownTypesTestPluginCache(cache wazero.CompilationCache) KnownTypesTestPlug
 	}
 }
 func NewKnownTypesTestPlugin(ctx context.Context, opts ...KnownTypesTestPluginOption) (*KnownTypesTestPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &KnownTypesTestPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
@@ -237,7 +236,6 @@ func EmptyTestPluginCache(cache wazero.CompilationCache) EmptyTestPluginOption {
 	}
 }
 func NewEmptyTestPlugin(ctx context.Context, opts ...EmptyTestPluginOption) (*EmptyTestPlugin, error) {
-
 	cache := wazero.NewCompilationCache()
 	o := &EmptyTestPlugin{
 		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -52,6 +52,7 @@ func (p *KnownTypesTestPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *KnownTypesTestPlugin) Load(ctx context.Context, pluginPath string) (KnownTypesTest, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {
@@ -218,6 +219,7 @@ func (p *EmptyTestPlugin) Close(ctx context.Context) (err error) {
 	}
 	return
 }
+
 func (p *EmptyTestPlugin) Load(ctx context.Context, pluginPath string) (EmptyTest, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -12,6 +12,7 @@ import (
 	context "context"
 	errors "errors"
 	fmt "fmt"
+	options "github.com/knqyf263/go-plugin/options"
 	emptypb "github.com/knqyf263/go-plugin/types/known/emptypb"
 	wazero "github.com/tetratelabs/wazero"
 	api "github.com/tetratelabs/wazero/api"
@@ -26,52 +27,24 @@ type KnownTypesTestPluginOption func(plugin *KnownTypesTestPlugin)
 
 type KnownTypesTestPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
-	cache        wazero.CompilationCache
 	moduleConfig wazero.ModuleConfig
 }
 
-type KnownTypesTestPluginNewRuntime func(context.Context) (wazero.Runtime, error)
-
-func KnownTypesTestPluginRuntime(newRuntime KnownTypesTestPluginNewRuntime) KnownTypesTestPluginOption {
-	return func(h *KnownTypesTestPlugin) {
-		h.newRuntime = newRuntime
-	}
-}
-
-func KnownTypesTestPluginModuleConfig(moduleConfig wazero.ModuleConfig) KnownTypesTestPluginOption {
-	return func(h *KnownTypesTestPlugin) {
-		h.moduleConfig = moduleConfig
-	}
-}
-
-func KnownTypesTestPluginCache(cache wazero.CompilationCache) KnownTypesTestPluginOption {
-	return func(h *KnownTypesTestPlugin) {
-		h.cache = cache
-	}
-}
-func NewKnownTypesTestPlugin(ctx context.Context, opts ...KnownTypesTestPluginOption) (*KnownTypesTestPlugin, error) {
-	cache := wazero.NewCompilationCache()
-	o := &KnownTypesTestPlugin{
-		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
-			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
-		},
-		cache:        cache,
-		moduleConfig: wazero.NewModuleConfig(),
-	}
+func NewKnownTypesTestPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*KnownTypesTestPlugin, error) {
+	o := options.NewWazeroConfig()
 
 	for _, opt := range opts {
 		opt(o)
 	}
 
-	return o, nil
+	return &KnownTypesTestPlugin{
+		newRuntime:   o.NewRuntime,
+		moduleConfig: o.ModuleConfig,
+	}, nil
 }
 func (p *KnownTypesTestPlugin) Close(ctx context.Context) (err error) {
-	if c := p.cache; c != nil {
-		err = c.Close(ctx)
-	}
 	return
 }
-
 func (p *KnownTypesTestPlugin) Load(ctx context.Context, pluginPath string) (KnownTypesTest, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {
@@ -212,52 +185,24 @@ type EmptyTestPluginOption func(plugin *EmptyTestPlugin)
 
 type EmptyTestPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
-	cache        wazero.CompilationCache
 	moduleConfig wazero.ModuleConfig
 }
 
-type EmptyTestPluginNewRuntime func(context.Context) (wazero.Runtime, error)
-
-func EmptyTestPluginRuntime(newRuntime EmptyTestPluginNewRuntime) EmptyTestPluginOption {
-	return func(h *EmptyTestPlugin) {
-		h.newRuntime = newRuntime
-	}
-}
-
-func EmptyTestPluginModuleConfig(moduleConfig wazero.ModuleConfig) EmptyTestPluginOption {
-	return func(h *EmptyTestPlugin) {
-		h.moduleConfig = moduleConfig
-	}
-}
-
-func EmptyTestPluginCache(cache wazero.CompilationCache) EmptyTestPluginOption {
-	return func(h *EmptyTestPlugin) {
-		h.cache = cache
-	}
-}
-func NewEmptyTestPlugin(ctx context.Context, opts ...EmptyTestPluginOption) (*EmptyTestPlugin, error) {
-	cache := wazero.NewCompilationCache()
-	o := &EmptyTestPlugin{
-		newRuntime: func(ctx context.Context) (wazero.Runtime, error) {
-			return wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().WithCompilationCache(cache)), nil
-		},
-		cache:        cache,
-		moduleConfig: wazero.NewModuleConfig(),
-	}
+func NewEmptyTestPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*EmptyTestPlugin, error) {
+	o := options.NewWazeroConfig()
 
 	for _, opt := range opts {
 		opt(o)
 	}
 
-	return o, nil
+	return &EmptyTestPlugin{
+		newRuntime:   o.NewRuntime,
+		moduleConfig: o.ModuleConfig,
+	}, nil
 }
 func (p *EmptyTestPlugin) Close(ctx context.Context) (err error) {
-	if c := p.cache; c != nil {
-		err = c.Close(ctx)
-	}
 	return
 }
-
 func (p *EmptyTestPlugin) Load(ctx context.Context, pluginPath string) (EmptyTest, error) {
 	b, err := os.ReadFile(pluginPath)
 	if err != nil {

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -28,6 +28,7 @@ type KnownTypesTestPluginOption func(plugin *KnownTypesTestPlugin)
 type KnownTypesTestPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
 	moduleConfig wazero.ModuleConfig
+	runtimes     []wazero.Runtime
 }
 
 func NewKnownTypesTestPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*KnownTypesTestPlugin, error) {
@@ -42,7 +43,13 @@ func NewKnownTypesTestPlugin(ctx context.Context, opts ...options.WazeroConfigOp
 		moduleConfig: o.ModuleConfig,
 	}, nil
 }
+
 func (p *KnownTypesTestPlugin) Close(ctx context.Context) (err error) {
+	for i := range p.runtimes {
+		if r := p.runtimes[i]; r != nil {
+			err = r.Close(ctx)
+		}
+	}
 	return
 }
 func (p *KnownTypesTestPlugin) Load(ctx context.Context, pluginPath string) (KnownTypesTest, error) {
@@ -56,6 +63,7 @@ func (p *KnownTypesTestPlugin) Load(ctx context.Context, pluginPath string) (Kno
 	if err != nil {
 		return nil, err
 	}
+	p.runtimes = append(p.runtimes, r)
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err
@@ -186,6 +194,7 @@ type EmptyTestPluginOption func(plugin *EmptyTestPlugin)
 type EmptyTestPlugin struct {
 	newRuntime   func(context.Context) (wazero.Runtime, error)
 	moduleConfig wazero.ModuleConfig
+	runtimes     []wazero.Runtime
 }
 
 func NewEmptyTestPlugin(ctx context.Context, opts ...options.WazeroConfigOption) (*EmptyTestPlugin, error) {
@@ -200,7 +209,13 @@ func NewEmptyTestPlugin(ctx context.Context, opts ...options.WazeroConfigOption)
 		moduleConfig: o.ModuleConfig,
 	}, nil
 }
+
 func (p *EmptyTestPlugin) Close(ctx context.Context) (err error) {
+	for i := range p.runtimes {
+		if r := p.runtimes[i]; r != nil {
+			err = r.Close(ctx)
+		}
+	}
 	return
 }
 func (p *EmptyTestPlugin) Load(ctx context.Context, pluginPath string) (EmptyTest, error) {
@@ -214,6 +229,7 @@ func (p *EmptyTestPlugin) Load(ctx context.Context, pluginPath string) (EmptyTes
 	if err != nil {
 		return nil, err
 	}
+	p.runtimes = append(p.runtimes, r)
 
 	if _, err = wasi_snapshot_preview1.NewBuilder(r).Instantiate(ctx); err != nil {
 		return nil, err

--- a/tests/well-known/well_known_test.go
+++ b/tests/well-known/well_known_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestWellKnownTypes(t *testing.T) {
 	ctx := context.Background()
-	p, err := proto.NewKnownTypesTestPlugin(ctx, proto.KnownTypesTestPluginOption{})
+	p, err := proto.NewKnownTypesTestPlugin(ctx)
 	require.NoError(t, err)
 	defer p.Close(ctx)
 
@@ -102,7 +102,7 @@ func TestWellKnownTypes(t *testing.T) {
 
 func TestEmpty(t *testing.T) {
 	ctx := context.Background()
-	p, err := proto.NewEmptyTestPlugin(ctx, proto.EmptyTestPluginOption{})
+	p, err := proto.NewEmptyTestPlugin(ctx)
 	require.NoError(t, err)
 
 	plugin, err := p.Load(ctx, "plugin/plugin.wasm")


### PR DESCRIPTION
*Issue #, if available:*
fixes #21

*Description of changes:*
This PR allows to provide custom options for following configurations during plugin initialization
- Runtime
- ModuleConfig
- CompilationCache

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
