### PR TITLE
Fix protoc-gen-go-plugin generated version in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,10 @@ jobs:
           go-version-file: go.mod
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.4.1
-          args: release --rm-dist --timeout 30m
+          distribution: goreleaser
+          version: v1.16.1
+          args: release --clean --timeout 30m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 .idea
 .DS_Store
 *.wasm
+dist/

--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -6,7 +6,7 @@ builds:
     ldflags:
       - -s -w
       - "-extldflags '-static'"
-      - -X version.Version={{.Version}}
+      - -X github.com/knqyf263/go-plugin/version.Version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:
@@ -40,6 +40,7 @@ nfpms:
 
 archives:
   -
+    rlcp: true
     format: tar.gz
     name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}-{{.Arch}}"
     files:


### PR DESCRIPTION
*Issue #, if available:*
Fixes #37

*Description of changes:*
Seems to release process should be running again to validate `goreleaser-action` configuration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
