### PR TITLE
Able to specify protoc-gen-go-plugin version on local build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,15 @@ GOPATH := $(shell go env GOPATH)
 GOBIN := $(if $(GOPATH),$(GOPATH)/bin,/usr/local/bin)
 
 go_sources := $(shell find cmd encoding gen genid version wasm -name "*.go")
+ifdef VERSION
+	LDFLAGS := -ldflags="-X github.com/knqyf263/go-plugin/version.Version=${VERSION}"
+endif
 
 .PHONY: build
 build: $(GOBIN)/protoc-gen-go-plugin
 
 $(GOBIN)/protoc-gen-go-plugin: $(go_sources)
-	go build -o $(GOPATH)/bin/protoc-gen-go-plugin cmd/protoc-gen-go-plugin/main.go
+	go build ${LDFLAGS} -o $(GOPATH)/bin/protoc-gen-go-plugin cmd/protoc-gen-go-plugin/main.go
 
 tinygo_examples := $(shell find examples -path "*/plugin*/*.go")
 .PHONY: build.examples


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This small fix allows to specify the `protoc-gen-go-plugin` version on local build with `VERSION` variable, i.e.
```bash
VERSION=v0.7.0-dev make build
```  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
