### PR TITLE
Fix performance degradation while host functions call

### DIFF
--- a/examples/host-function-library/library/json-parser/export/library_plugin.pb.go
+++ b/examples/host-function-library/library/json-parser/export/library_plugin.pb.go
@@ -32,6 +32,7 @@ func (h parserLibrary) ParseJson(ctx context.Context, request *ParseJsonRequest)
 	}
 	ptr, size := wasm.ByteToPtr(buf)
 	ptrSize := _parse_json(ptr, size)
+	wasm.FreePtr(ptr)
 
 	ptr = uint32(ptrSize >> 32)
 	size = uint32(ptrSize)

--- a/examples/host-function-library/proto/greet_plugin.pb.go
+++ b/examples/host-function-library/proto/greet_plugin.pb.go
@@ -69,6 +69,7 @@ func (h hostFunctions) San(ctx context.Context, request *SanRequest) (*SanRespon
 	}
 	ptr, size := wasm.ByteToPtr(buf)
 	ptrSize := _san(ptr, size)
+	wasm.FreePtr(ptr)
 
 	ptr = uint32(ptrSize >> 32)
 	size = uint32(ptrSize)

--- a/examples/host-functions/greeting/greet_plugin.pb.go
+++ b/examples/host-functions/greeting/greet_plugin.pb.go
@@ -70,6 +70,7 @@ func (h hostFunctions) HttpGet(ctx context.Context, request *HttpGetRequest) (*H
 	}
 	ptr, size := wasm.ByteToPtr(buf)
 	ptrSize := _http_get(ptr, size)
+	wasm.FreePtr(ptr)
 
 	ptr = uint32(ptrSize >> 32)
 	size = uint32(ptrSize)
@@ -94,6 +95,7 @@ func (h hostFunctions) Log(ctx context.Context, request *LogRequest) (*emptypb.E
 	}
 	ptr, size := wasm.ByteToPtr(buf)
 	ptrSize := _log(ptr, size)
+	wasm.FreePtr(ptr)
 
 	ptr = uint32(ptrSize >> 32)
 	size = uint32(ptrSize)

--- a/gen/plugin.go
+++ b/gen/plugin.go
@@ -115,6 +115,7 @@ func genHostFunctions(g *protogen.GeneratedFile, f *fileInfo) {
 			}
 			ptr, size := %s(buf)
 			ptrSize := _%s(ptr, size)
+			%s(ptr)
 
 			ptr = uint32(ptrSize >> 32)
 			size = uint32(ptrSize)
@@ -132,6 +133,7 @@ func genHostFunctions(g *protogen.GeneratedFile, f *fileInfo) {
 			g.QualifiedGoIdent(method.Output.GoIdent),
 			g.QualifiedGoIdent(pluginWasmPackage.Ident("ByteToPtr")),
 			importedName,
+			g.QualifiedGoIdent(pluginWasmPackage.Ident("FreePtr")),
 			g.QualifiedGoIdent(pluginWasmPackage.Ident("PtrToByte")),
 			g.QualifiedGoIdent(method.Output.GoIdent),
 		))

--- a/tests/fields/bench_test.go
+++ b/tests/fields/bench_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/knqyf263/go-plugin/tests/fields/proto"
+)
+
+func BenchmarkFields(b *testing.B) {
+	b.ReportAllocs()
+	ctx := context.Background()
+	p, err := proto.NewFieldTestPlugin(ctx)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	plugin, err := p.Load(ctx, "plugin/plugin.wasm")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer plugin.Close(ctx)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err = plugin.Test(ctx, &proto.Request{
+			A: 1.2,
+			B: 3.4,
+			C: 5,
+			D: -6,
+			E: 7,
+			F: 8,
+			G: 9,
+			H: -10,
+			I: 11,
+			J: 12,
+			K: 13,
+			L: -14,
+			M: false,
+			N: "foo",
+			O: []byte("hoge"),
+			P: []string{"a", "b"},
+			Q: map[string]*proto.IntValue{
+				"key": {A: 15},
+			},
+			R: &proto.Request_Nested{
+				A: "samurai",
+			},
+			S: proto.Enum_A,
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/tests/host-functions/bench_test.go
+++ b/tests/host-functions/bench_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/tetratelabs/wazero"
+
+	"github.com/knqyf263/go-plugin/tests/host-functions/proto"
+)
+
+func BenchmarkHostFunctions(b *testing.B) {
+	b.ReportAllocs()
+	ctx := context.Background()
+	mc := wazero.NewModuleConfig().WithStdout(os.Stdout)
+	p, err := proto.NewGreeterPlugin(ctx, proto.WazeroRuntime(func(ctx context.Context) (wazero.Runtime, error) {
+		return proto.DefaultWazeroRuntime()(ctx)
+	}), proto.WazeroModuleConfig(mc))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Pass my host functions that are embedded into the plugin.
+	plugin, err := p.Load(ctx, "plugin/plugin.wasm", myHostFunctions{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer plugin.Close(ctx)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := plugin.Greet(ctx, &proto.GreetRequest{
+			Name: "Sato",
+		}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/tests/host-functions/proto/host_plugin.pb.go
+++ b/tests/host-functions/proto/host_plugin.pb.go
@@ -69,6 +69,7 @@ func (h hostFunctions) ParseJson(ctx context.Context, request *ParseJsonRequest)
 	}
 	ptr, size := wasm.ByteToPtr(buf)
 	ptrSize := _parse_json(ptr, size)
+	wasm.FreePtr(ptr)
 
 	ptr = uint32(ptrSize >> 32)
 	size = uint32(ptrSize)

--- a/wasm/plugin.go
+++ b/wasm/plugin.go
@@ -33,3 +33,7 @@ func ByteToPtr(buf []byte) (uint32, uint32) {
 
 	return uint32(uintptr(ptr)), uint32(len(buf))
 }
+
+func FreePtr(ptr uint32) {
+	C.free(unsafe.Pointer(uintptr(ptr)))
+}


### PR DESCRIPTION
*Issue #, if available:*
This is probably one of the option to fix performance issue  

*Description of changes:*
Hosts functions performance tests before fix
```bash
/u01/git/wasm/go-plugin/tests/host-functions
go test -run='^$' -bench '^Benchmark' ./... -count=6 -timeout 99999s
name              time/op
HostFunctions-12  1.76ms ±12%

name              alloc/op
HostFunctions-12  5.95kB ± 6%

name              allocs/op
HostFunctions-12    25.0 ± 0%
```

Hosts functions performance tests after fix
```bash
/u01/git/wasm/go-plugin/tests/host-functions
go test -run='^$' -bench '^Benchmark' ./... -count=6
HostFunctions-12  13.5µs ±12%

name              alloc/op
HostFunctions-12  6.27kB ± 1%

name              allocs/op
HostFunctions-12    25.0 ± 0%
```

Hosts functions performance tests for `v0.7.0`
```bash
/u01/git/wasm/go-plugin/tests/host-functions
go test -run='^$' -bench '^Benchmark' ./... -count=6
HostFunctions-12  10.6µs ±11%

name              alloc/op
HostFunctions-12  5.99kB ± 2%

name              allocs/op
HostFunctions-12    24.0 ± 0%
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

cc: @codefromthecrypt , @lburgazzoli 
