### PR TITLE
Use `unsafe.Slice` instead of `reflect.SliceHeader` to build byte slice

### DIFF
--- a/wasm/plugin.go
+++ b/wasm/plugin.go
@@ -8,16 +8,12 @@ package wasm
 import "C"
 
 import (
-	"reflect"
 	"unsafe"
 )
 
 func PtrToByte(ptr, size uint32) []byte {
-	var b []byte
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	s.Len = uintptr(size)
-	s.Cap = uintptr(size)
-	s.Data = uintptr(ptr)
+	b := unsafe.Slice((*byte)(unsafe.Pointer(uintptr(ptr))), size)
+
 	return b
 }
 


### PR DESCRIPTION
*Issue #, if available:*
#64

*Description of changes:*
Use `unsafe.Slice` instead of `reflect.SliceHeader` to build byte slice

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
