### PR TITLE
Fix memory leak

### DIFF
--- a/examples/helloworld/greeting/greet_host.pb.go
+++ b/examples/helloworld/greeting/greet_host.pb.go
@@ -167,11 +167,6 @@ func (p *greeterPlugin) Greet(ctx context.Context, request *GreetRequest) (*Gree
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/examples/host-function-library/proto/greet_host.pb.go
+++ b/examples/host-function-library/proto/greet_host.pb.go
@@ -223,11 +223,6 @@ func (p *greeterPlugin) Greet(ctx context.Context, request *GreetRequest) (*Gree
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/examples/host-functions/greeting/greet_host.pb.go
+++ b/examples/host-functions/greeting/greet_host.pb.go
@@ -259,11 +259,6 @@ func (p *greeterPlugin) Greet(ctx context.Context, request *GreetRequest) (*Gree
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/examples/known-types/known/known_host.pb.go
+++ b/examples/known-types/known/known_host.pb.go
@@ -167,11 +167,6 @@ func (p *wellKnownPlugin) Diff(ctx context.Context, request *DiffRequest) (*Diff
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/examples/wasi/cat/cat_host.pb.go
+++ b/examples/wasi/cat/cat_host.pb.go
@@ -167,11 +167,6 @@ func (p *fileCatPlugin) Cat(ctx context.Context, request *FileCatRequest) (*File
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/gen/host.go
+++ b/gen/host.go
@@ -355,11 +355,6 @@ func genPluginMethod(g *protogen.GeneratedFile, f *fileInfo, method *protogen.Me
 				resSize &^= %s
 			}
 
-			// We don't need the memory after deserialization: make sure it is freed.
-			if resPtr != 0 {
-				defer p.free.Call(ctx, uint64(resPtr))     
-			}
-
 			// The pointer is a linear memory offset, which is where we write the name.
 			bytes, ok := p.module.Memory().Read(resPtr, resSize)
 			if !ok {

--- a/tests/fields/proto/fields_host.pb.go
+++ b/tests/fields/proto/fields_host.pb.go
@@ -180,11 +180,6 @@ func (p *fieldTestPlugin) Test(ctx context.Context, request *Request) (*Response
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
@@ -241,11 +236,6 @@ func (p *fieldTestPlugin) TestEmptyInput(ctx context.Context, request *emptypb.E
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
@@ -300,11 +290,6 @@ func (p *fieldTestPlugin) TestError(ctx context.Context, request *ErrorRequest) 
 	if (resSize & (1 << 31)) > 0 {
 		isErrResponse = true
 		resSize &^= (1 << 31)
-	}
-
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
 	}
 
 	// The pointer is a linear memory offset, which is where we write the name.

--- a/tests/host-functions/proto/host_host.pb.go
+++ b/tests/host-functions/proto/host_host.pb.go
@@ -223,11 +223,6 @@ func (p *greeterPlugin) Greet(ctx context.Context, request *GreetRequest) (*Gree
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/tests/import/proto/bar/bar_host.pb.go
+++ b/tests/import/proto/bar/bar_host.pb.go
@@ -167,11 +167,6 @@ func (p *barPlugin) Hello(ctx context.Context, request *Request) (*Reply, error)
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/tests/import/proto/foo/foo_host.pb.go
+++ b/tests/import/proto/foo/foo_host.pb.go
@@ -168,11 +168,6 @@ func (p *fooPlugin) Hello(ctx context.Context, request *Request) (*bar.Reply, er
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {

--- a/tests/well-known/proto/known_host.pb.go
+++ b/tests/well-known/proto/known_host.pb.go
@@ -168,11 +168,6 @@ func (p *knownTypesTestPlugin) Test(ctx context.Context, request *Request) (*Res
 		resSize &^= (1 << 31)
 	}
 
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
-	}
-
 	// The pointer is a linear memory offset, which is where we write the name.
 	bytes, ok := p.module.Memory().Read(resPtr, resSize)
 	if !ok {
@@ -339,11 +334,6 @@ func (p *emptyTestPlugin) DoNothing(ctx context.Context, request *emptypb.Empty)
 	if (resSize & (1 << 31)) > 0 {
 		isErrResponse = true
 		resSize &^= (1 << 31)
-	}
-
-	// We don't need the memory after deserialization: make sure it is freed.
-	if resPtr != 0 {
-		defer p.free.Call(ctx, uint64(resPtr))
 	}
 
 	// The pointer is a linear memory offset, which is where we write the name.

--- a/wasm/plugin.go
+++ b/wasm/plugin.go
@@ -5,6 +5,7 @@
 package wasm
 
 import (
+	"runtime"
 	"unsafe"
 )
 
@@ -38,6 +39,9 @@ func Malloc(size uint32) uint32 {
 func Free(ptr uint32) {
 	// Remove the slice from the allocations map so the GC can reclaim it later.
 	delete(allocations, ptr)
+
+	// Let GC run
+	runtime.Gosched()
 }
 
 func PtrToByte(ptr, size uint32) []byte {


### PR DESCRIPTION
*Issue #, if available:*
#78 

*Description of changes:*
The reason for the issue is that GC not run due to cooperative nature of Wasm runtime.

This is fixed by explicitly yielding control with `runtime.Gosched`. Another option is to force run of GC. It also works, however performance is worse, apparently because it's not necessary to have whole GC cycle on every call to `Free`. It's enough to make sure that it will run eventually.

I also removed unnecessary call to `Free` on memory managed by Wasm module itself. This is not needed in any case:
- On Big Go it's a no-op since corresponding map won't contain entry for the given pointer
- On TinyGo it also makes no sense since memory is allocated by module itself, so it's GC area of responsibility, and outside call to `Free` will either be no-op or lead to further difficult-to-debug memory problems

Last point also reduces overall latency by few microseconds which could have been counted in highly loaded systems.

@knqyf263 I didn't add benchmark tests which I used when reproducing #78, but if you think they make any sense, I can add `BenchmarkGreetMorning` and `BenchmarkGreetEvening` similar to the code in the above issue. Not sure if it's ok to run them during test phase in CI/CD. It will need a couple of minutes to complete and should fail because of OOM if original issue not fixed.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
