### PR TITLE
protoc flag flexibility

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .DS_Store
 *.wasm
 dist/
+.direnv/

--- a/cmd/protoc-gen-go-plugin/main.go
+++ b/cmd/protoc-gen-go-plugin/main.go
@@ -13,8 +13,14 @@ func main() {
 	var flags flag.FlagSet
 	disablePbGen := flags.Bool("disable_pb_gen", false, "disable .pb.go generation")
 	wasmPackage := flags.String("wasm_package", "github.com/knqyf263/go-plugin/wasm", "override package that provide wasm memory management")
+	useGoPluginKnownTypes := flags.Bool("goplugin_known_types", true, "use go-plugin known types")
 	protogen.Options{ParamFunc: flags.Set}.Run(func(plugin *protogen.Plugin) error {
-		g, err := gen.NewGenerator(plugin)
+		opts := gen.Options{
+			UseGoPluginKnownTypes: *useGoPluginKnownTypes,
+			DisablePBGen:          *disablePbGen,
+			WasmPackage:           *wasmPackage,
+		}
+		g, err := gen.NewGenerator(plugin, opts)
 		if err != nil {
 			return err
 		}
@@ -23,7 +29,7 @@ func main() {
 			if !f.Generate {
 				continue
 			}
-			g.GenerateFiles(f, gen.Options{DisablePBGen: *disablePbGen, WasmPackage: *wasmPackage})
+			g.GenerateFiles(f, opts)
 		}
 
 		plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)

--- a/cmd/protoc-gen-go-plugin/main.go
+++ b/cmd/protoc-gen-go-plugin/main.go
@@ -12,6 +12,7 @@ import (
 func main() {
 	var flags flag.FlagSet
 	disablePbGen := flags.Bool("disable_pb_gen", false, "disable .pb.go generation")
+	wasmPackage := flags.String("wasm_package", "github.com/knqyf263/go-plugin/wasm", "override package that provide wasm memory management")
 	protogen.Options{ParamFunc: flags.Set}.Run(func(plugin *protogen.Plugin) error {
 		g, err := gen.NewGenerator(plugin)
 		if err != nil {
@@ -22,7 +23,7 @@ func main() {
 			if !f.Generate {
 				continue
 			}
-			g.GenerateFiles(f, gen.Options{DisablePBGen: *disablePbGen})
+			g.GenerateFiles(f, gen.Options{DisablePBGen: *disablePbGen, WasmPackage: *wasmPackage})
 		}
 
 		plugin.SupportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761597516,
+        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "bitmagnet dev shell";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+    pkgs = import nixpkgs {
+      system = system;
+    };
+    in {
+      formatter = pkgs.alejandra;
+      devShells = {
+        default = pkgs.mkShell {
+          hardeningDisable = [ "fortify" ]; 
+          packages = with pkgs; [
+            go
+            golangci-lint
+            protobuf
+            protoc-gen-go
+          ];
+        };
+      };
+    });
+}

--- a/gen/main.go
+++ b/gen/main.go
@@ -90,11 +90,12 @@ type Generator struct {
 }
 
 type Options struct {
-	DisablePBGen bool
-	WasmPackage  string
+	UseGoPluginKnownTypes bool
+	DisablePBGen          bool
+	WasmPackage           string
 }
 
-func NewGenerator(plugin *protogen.Plugin) (*Generator, error) {
+func NewGenerator(plugin *protogen.Plugin, opts Options) (*Generator, error) {
 	ext := &vtgenerator.Extensions{}
 	featureNames := []string{"marshal", "unmarshal", "size"}
 
@@ -104,7 +105,7 @@ func NewGenerator(plugin *protogen.Plugin) (*Generator, error) {
 	}
 
 	for _, f := range plugin.Files {
-		if !f.Generate {
+		if !f.Generate || !opts.UseGoPluginKnownTypes {
 			continue
 		}
 

--- a/gen/main.go
+++ b/gen/main.go
@@ -76,7 +76,7 @@ var (
 	wazeroSysPackage  goImportPath = protogen.GoImportPath("github.com/tetratelabs/wazero/sys")
 	wazeroWasiPackage goImportPath = protogen.GoImportPath("github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1")
 
-	pluginWasmPackage goImportPath = protogen.GoImportPath("github.com/knqyf263/go-plugin/wasm")
+	pluginWasmPackage goImportPath = protogen.GoImportPath("")
 )
 
 type goImportPath interface {
@@ -91,6 +91,7 @@ type Generator struct {
 
 type Options struct {
 	DisablePBGen bool
+	WasmPackage  string
 }
 
 func NewGenerator(plugin *protogen.Plugin) (*Generator, error) {
@@ -144,6 +145,7 @@ func replaceImport(m *protogen.Message) {
 // GenerateFiles generates the contents of a .pb.go file.
 func (gg *Generator) GenerateFiles(file *protogen.File, opts Options) *protogen.GeneratedFile {
 	f := gg.newFileInfo(file)
+	pluginWasmPackage = protogen.GoImportPath(opts.WasmPackage)
 	gg.generatePBFile(f, opts.DisablePBGen)
 	gg.generateHostFile(f)
 	gg.generatePluginFile(f)


### PR DESCRIPTION
*Description of changes:*
This PR contains three parts
- **flake.nix** For users / developers that use Nix, setup development environment dependencies
- **wasm_package** `protoc` option.   This enables a custom version of `wasm` package to be used
   - there are edge cases where memory leaks are possible.  For example:
   https://github.com/knqyf263/go-plugin/blob/6e1c26d67ef2e05dd8ea33d68edccd46f7dd8654/wasm/host.go#L34
     Never releases this memory.   I have a implemented 
https://github.com/knqyf263/go-plugin/blob/6e1c26d67ef2e05dd8ea33d68edccd46f7dd8654/wasm/plugin.go#L34
    and
https://github.com/knqyf263/go-plugin/blob/6e1c26d67ef2e05dd8ea33d68edccd46f7dd8654/wasm/plugin.go#L39

   to effectively do a TTL on allocations.  The use case I have are many short lived requests.   This custom implementation is not always applicable.   Hence with this flag it adds flexibility to use implementations of these core functions that are more applicable to use case. 
- **goplugin_known_types** This flag enables user to disable **go-plugin** implementation of known/types.  This serves as a way of deprecating these.   The use case I have is more assured consistency with https://github.com/piotr-oles/as-proto 

For two new flags, both default such that there is no change in behaviour unless user specifies them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
